### PR TITLE
Fix anchor links to headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ This is a framework for building CLIs in Node.js. This framework was built out o
 # ✨ Features
 
 * **Flag/Argument parsing** - No CLI framework would be complete without a flag parser. We've built a custom one from years of experimentation that we feel consistently handles user input flexible enough for the user to be able to easily use the CLI in ways they expect, but without comprisiming strictness guarantees to the developer.
-* **CLI Generator** - Run a single command to scaffold out a fully functional CLI and get started quickly. See [Usage](#usage) below.
+* **CLI Generator** - Run a single command to scaffold out a fully functional CLI and get started quickly. See [Usage](#-usage) below.
 * **Testing Helpers** - We've put a lot of work into making commands easily testable and easy to mock out stdout/stderr. The generator will automatically create [scaffolded tests](https://github.com/oclif/example-multi-ts/blob/master/test/commands/hello.test.ts).
 * **Auto-documentation** - By default you can pass `--help` to the CLI to get help such as flag options and argument information. This information is also automatically placed in the README whenever the npm package of the CLI is published. See the [multi-command CLI example](https://github.com/oclif/example-multi-ts)
-* **Plugins** - Using plugins, users of the CLI can extend it with new functionality, a CLI can be split into modular components, and functionality can be shared amongst multiple CLIs. See [Building your own plugin](#buildingyourownplugin) below.
+* **Plugins** - Using plugins, users of the CLI can extend it with new functionality, a CLI can be split into modular components, and functionality can be shared amongst multiple CLIs. See [Building your own plugin](#-building-your-own-plugin) below.
 * **Hooks** - Use lifecycle hooks to run functionality any time a CLI starts, or on custom triggers. Use this whenever custom functionality needs to be shared between various components of the CLI.
 * **TypeScript (or not)** - Everything in the core of oclif is written in TypeScript and the generator can build fully configured TypeScript CLIs or just plain JavaScript CLIs. By virtue of static properties in TypeScript the syntax is a bit cleaner in TypeScript—but everything will work no matter which language you choose. If you use plugins support, the CLI will automatically use `ts-node` to run the plugins making it easy and fast to use TypeScript with minimal-to-no boilerplate needed for any oclif CLI.
 * **Coming soon: man pages** - In addition to in-CLI help through `--help` and the README markdown help generation, the CLI can also automatically create man pages for all of its commands.
@@ -70,9 +70,9 @@ src/
     └── destroy.ts
 ```
 
-Multi-command CLIs may also include [plugins](#plugins).
+Multi-command CLIs may also include [plugins](#-plugins).
 
-See below for information on [nesting commands within topics](#topics).
+See below for information on [nesting commands within topics](#-topics).
 
 # 🏗 Usage
 
@@ -133,7 +133,7 @@ export class MyCommand extends Command {
 }
 ```
 
-The only part that is required is the run function. Accept user input with [arguments](#arguments) and [flag options](#flag-options).
+The only part that is required is the run function. Accept user input with [arguments](#-arguments) and [flag options](#-flag-options).
 
 In JavaScript:
 
@@ -415,11 +415,11 @@ Run `npx oclif plugin mynewplugin` to create a plugin in a new directory. This w
 <!-- commands -->
 # Commands
 
-* [oclif command NAME](#command)
-* [oclif help [COMMAND]](#help)
-* [oclif multi [PATH]](#multi)
-* [oclif plugin [PATH]](#plugin)
-* [oclif single [PATH]](#single)
+* [oclif command NAME](#command-name)
+* [oclif help [COMMAND]](#help-command)
+* [oclif multi [PATH]](#multi-path)
+* [oclif plugin [PATH]](#plugin-path)
+* [oclif single [PATH]](#single-path)
 ## command NAME
 
 add a command to an existing CLI or plugin


### PR DESCRIPTION
Since emoji headings were introduced in https://github.com/oclif/oclif/commit/fb7765cf6e6aee9be110eab94e596cdc85c323dc, the links to headings were broken at a few points.

I took the chance to validate all the links in the readme (via [remark](https://remark.js.org/)) and fix them.

The only outlier is "Other Command Options", as the cog seems to have a variation selector in front, which makes GitHub treat the anchor as `#%EF%B8%8F-other-command-options`. We could potentially hardcore the link to this, but maybe we can find a different solution to this.