### PR TITLE
fix: return a promise from yeoman callback style so it actually awaits

### DIFF
--- a/src/command_base.ts
+++ b/src/command_base.ts
@@ -10,6 +10,11 @@ export default abstract class CommandBase extends Command {
       `oclif:${type}`
     )
 
-    await env.run(`oclif:${type}`, generatorOptions)
+    await new Promise((resolve, reject) => {
+      env.run(`oclif:${type}`, generatorOptions, (err: Error, results: any) => {
+        if (err) reject(err)
+        else resolve(results)
+      })
+    })
   }
 }


### PR DESCRIPTION
Yeomans env.run doesn't seem to return a promise, but takes a callback. 