### PR TITLE
Remove Greenkeeper readme template badge

### DIFF
--- a/templates/README.md.ejs
+++ b/templates/README.md.ejs
@@ -7,7 +7,6 @@
 [![CircleCI](https://circleci.com/gh/<%= repository %>/tree/master.svg?style=shield)](https://circleci.com/gh/<%= repository %>/tree/master)
 [![Appveyor CI](https://ci.appveyor.com/api/projects/status/github/<%= repository %>?branch=master&svg=true)](https://ci.appveyor.com/project/<%= repository %>/branch/master)
 [![Codecov](https://codecov.io/gh/<%= repository %>/branch/master/graph/badge.svg)](https://codecov.io/gh/<%= repository %>)
-[![Greenkeeper](https://badges.greenkeeper.io/<%= repository %>.svg)](https://greenkeeper.io/)
 [![Known Vulnerabilities](https://snyk.io/test/github/<%- repository %>/badge.svg)](https://snyk.io/test/github/<%- repository %>)
 [![Downloads/week](https://img.shields.io/npm/dw/<%= pjson.name %>.svg)](https://npmjs.org/package/<%= pjson.name %>)
 [![License](https://img.shields.io/npm/l/<%= pjson.name %>.svg)](https://github.com/<%= repository %>/blob/master/package.json)


### PR DESCRIPTION
As mentioned in #70, this commit removes the Greenkeeper badge from the readme template.  If you feel I've missed something or need to make other changes, please let me know, and I'd be happy to take care of it.