### PR TITLE
Adding oclif logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+*(Add image here)*
+
 oclif: Node.JS Open CLI Framework
 =================================
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-*(Add image here)*
+[!](https://user-images.githubusercontent.com/449385/38243295-e0a47d58-372e-11e8-9bc0-8c02a6f4d2ac.png)  
 
 oclif: Node.JS Open CLI Framework
 =================================

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
-[!](https://user-images.githubusercontent.com/449385/38243295-e0a47d58-372e-11e8-9bc0-8c02a6f4d2ac.png)  
+<img src="https://user-images.githubusercontent.com/449385/38243295-e0a47d58-372e-11e8-9bc0-8c02a6f4d2ac.png" width="260" height="73">  
+
 
 oclif: Node.JS Open CLI Framework
 =================================


### PR DESCRIPTION
Let's add the `oclif` image to the README, similar to how it's done on https://github.com/atom/atom/blob/master/README.md.

I don't have access to the image, but put a placeholder where it should likely go. 👍 