### PR TITLE
fix(generators/command): assert cwd is a project

### DIFF
--- a/src/generators/command.ts
+++ b/src/generators/command.ts
@@ -24,8 +24,8 @@ class CommandGenerator extends Generator {
 
   async prompting() {
     this.pjson = this.fs.readJSON('package.json')
-    this.pjson.oclif = this.pjson.oclif || {}
     if (!this.pjson) throw new Error('not in a project directory')
+    this.pjson.oclif = this.pjson.oclif || {}
     this.log(yosay(`Adding a command to ${this.pjson.name} Version: ${version}`))
   }
 


### PR DESCRIPTION
I think we could have an even nicer error message here, but this is the obvious quick fix.

Fixes #91 