### PR TITLE
Update README.md: Fixed example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ hello world from ./src/hello.js!
 * TypeScript
   * [Multi-command CLI](https://github.com/oclif/example-multi-ts)
   * [Single-command CLI](https://github.com/oclif/example-single-ts)
-  * [Multi-command CLI Plugin](https://github.com/oclif/example-single-ts)
+  * [Multi-command CLI Plugin](https://github.com/oclif/example-plugin-ts)
 * JavaScript
   * [Multi-command CLI](https://github.com/oclif/example-multi-js)
   * [Single-command CLI](https://github.com/oclif/example-single-js)


### PR DESCRIPTION
This will fix the typo in the link to typescript plugin example repo. in the readme file.
