### PR TITLE
Fix command descriptions not showing up in the help

### DIFF
--- a/templates/src/command.js.ejs
+++ b/templates/src/command.js.ejs
@@ -9,8 +9,7 @@ class <%- klass %> extends Command {
   }
 }
 
-<%- klass %>.description = `
-Describe the command here
+<%- klass %>.description = `Describe the command here
 ...
 Extra documentation goes here
 `


### PR DESCRIPTION
This is for JavaScript-based commands. See discussion in https://github.com/oclif/oclif/issues/120