### PR TITLE
feat: make codecov optional

### DIFF
--- a/src/generators/app.ts
+++ b/src/generators/app.ts
@@ -42,6 +42,7 @@ class App extends Generator {
     defaults?: boolean
     mocha: boolean
     circleci: boolean
+    codecov: boolean
     'semantic-release': boolean
     typescript: boolean
     tslint: boolean
@@ -65,6 +66,7 @@ class App extends Generator {
     options: {
       mocha: boolean
       circleci: boolean
+      codecov: boolean
       typescript: boolean
       tslint: boolean
       yarn: boolean
@@ -73,6 +75,7 @@ class App extends Generator {
   }
   mocha!: boolean
   circleci!: boolean
+  codecov!: boolean
   semantic_release!: boolean
   ts!: boolean
   tslint!: boolean
@@ -94,6 +97,7 @@ class App extends Generator {
       defaults: opts.defaults,
       mocha: opts.options.includes('mocha'),
       circleci: opts.options.includes('circleci'),
+      codecov: opts.options.includes('codecov'),
       'semantic-release': opts.options.includes('semantic-release'),
       typescript: opts.options.includes('typescript'),
       tslint: opts.options.includes('tslint'),
@@ -227,6 +231,7 @@ class App extends Generator {
             {name: 'yarn (npm alternative)', value: 'yarn', checked: this.options.yarn || hasYarn},
             {name: 'mocha (testing framework)', value: 'mocha', checked: true},
             {name: 'circleci (continuous integration/delivery service)', value: 'circleci', checked: true},
+            {name: 'codecov (online code coverage report viewer)', value: 'codecov', checked: true},
             {name: 'typescript (static typing for javascript)', value: 'typescript', checked: true},
             {name: 'tslint (static analysis tool for typescript)', value: 'tslint', checked: true},
             {name: 'semantic-release (automated version management)', value: 'semantic-release', checked: this.options['semantic-release']}
@@ -249,6 +254,7 @@ class App extends Generator {
     this.yarn = this.options.yarn
     this.mocha = this.options.mocha
     this.circleci = this.options.circleci
+    this.codecov = this.options.codecov
     this.semantic_release = this.options['semantic-release']
 
     this.pjson.name = this.answers.name || defaults.name

--- a/templates/README.md.ejs
+++ b/templates/README.md.ejs
@@ -9,7 +9,9 @@
 [![CircleCI](https://circleci.com/gh/<%= repository %>/tree/master.svg?style=shield)](https://circleci.com/gh/<%= repository %>/tree/master)
 <% } %>
 [![Appveyor CI](https://ci.appveyor.com/api/projects/status/github/<%= repository %>?branch=master&svg=true)](https://ci.appveyor.com/project/<%= repository %>/branch/master)
+<% if (codecov) { %>
 [![Codecov](https://codecov.io/gh/<%= repository %>/branch/master/graph/badge.svg)](https://codecov.io/gh/<%= repository %>)
+<% } %>
 [![Downloads/week](https://img.shields.io/npm/dw/<%= pjson.name %>.svg)](https://npmjs.org/package/<%= pjson.name %>)
 [![License](https://img.shields.io/npm/l/<%= pjson.name %>.svg)](https://github.com/<%= repository %>/blob/master/package.json)
 

--- a/templates/appveyor.yml.ejs
+++ b/templates/appveyor.yml.ejs
@@ -24,12 +24,14 @@ test_script:
   - .\bin\run --help
 <%_ } _%>
   - <%- yarn ? 'yarn' : 'npm' %> test
+<% if (mocha && codecov) { %>
 after_test:
   - .\node_modules\.bin\nyc report --reporter text-lcov > coverage.lcov
   - ps: |
       $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
       Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
       bash codecov.sh
+<% } %>
 
 build: off
 

--- a/templates/circle.yml.ejs
+++ b/templates/circle.yml.ejs
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Testing
           command: <%- yarn ? 'yarn' : 'npm' %> test
-      <%_ if (mocha) { _%>
+      <%_ if (mocha && codecov) { _%>
       - run:
           name: Submitting code coverage to codecov
           command: |


### PR DESCRIPTION
Decided to just finish of all the optional add-on issues, as with the other two I've made it active by default, I also added a check in appveyor.yml to ensure mocha is there too, mirroring the circle.yml

Fixes #71 