### PR TITLE
fix: remove npm-shrinkwrap from multi

### DIFF
--- a/src/generators/app.ts
+++ b/src/generators/app.ts
@@ -288,10 +288,9 @@ class App extends Generator {
     }
     if (['plugin', 'multi'].includes(this.type)) {
       this.pjson.scripts.prepack = nps.series(this.pjson.scripts.prepare, 'oclif-dev manifest', 'oclif-dev readme', 'npm shrinkwrap')
-      this.pjson.scripts.postpack = `${rmf} oclif.manifest.json npm-shrinkwrap.json`
+      this.pjson.scripts.postpack = `${rmf} oclif.manifest.json`
       this.pjson.scripts.version = nps.series('oclif-dev readme', 'git add README.md')
       this.pjson.files.push('/oclif.manifest.json')
-      this.pjson.files.push('/npm-shrinkwrap.json')
     }
     if (this.type === 'plugin' && hasYarn) {
       // for plugins, add yarn.lock file to package so we can lock plugin dependencies


### PR DESCRIPTION
Since this is generating new CLIs for Yarn and NPM, both of which leverage lock files, seems like there shouldn't be a need to rm and bundle shrink wraps....