### PR TITLE
fix: update eslint to latest major in generator

### DIFF
--- a/src/generators/app.ts
+++ b/src/generators/app.ts
@@ -471,7 +471,7 @@ class App extends Generator {
       }
     } else {
       devDependencies.push(
-        'eslint@^4',
+        'eslint@^5',
         'eslint-config-oclif@^1',
       )
     }

--- a/src/generators/app.ts
+++ b/src/generators/app.ts
@@ -472,7 +472,7 @@ class App extends Generator {
     } else {
       devDependencies.push(
         'eslint@^5',
-        'eslint-config-oclif@^1',
+        'eslint-config-oclif@^3',
       )
     }
     if (isWindows) devDependencies.push('rimraf')


### PR DESCRIPTION
Debating whether this should be set to `latest` or just have to manually update. Eslint is now on major version 5, so this should reflect that...