### PR TITLE
Add pnpm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /node_modules
 /tmp
 package-lock.json
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ ARGUMENTS
 OPTIONS
   --defaults         use defaults for every setting
   --force            overwrite existing files
-  --options=options  (yarn|typescript|tslint|mocha)
+  --options=options  (yarn|pnpm|typescript|tslint|mocha)
 ```
 
 _See code: [src/commands/multi.ts](https://github.com/oclif/oclif/blob/v1.13.1/src/commands/multi.ts)_
@@ -217,7 +217,7 @@ ARGUMENTS
 OPTIONS
   --defaults         use defaults for every setting
   --force            overwrite existing files
-  --options=options  (yarn|typescript|tslint|mocha)
+  --options=options  (yarn|pnpm|typescript|tslint|mocha)
 ```
 
 _See code: [src/commands/plugin.ts](https://github.com/oclif/oclif/blob/v1.13.1/src/commands/plugin.ts)_
@@ -236,7 +236,7 @@ ARGUMENTS
 OPTIONS
   --defaults         use defaults for every setting
   --force            overwrite existing files
-  --options=options  (yarn|typescript|tslint|mocha)
+  --options=options  (yarn|pnpm|typescript|tslint|mocha)
 ```
 
 _See code: [src/commands/single.ts](https://github.com/oclif/oclif/blob/v1.13.1/src/commands/single.ts)_

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@oclif/plugin-help": "^2.1.6",
     "@oclif/plugin-not-found": "^1.2.2",
     "@oclif/plugin-warn-if-update-available": "^1.5.4",
+    "dargs": "^6.1.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.11",
     "nps-utils": "^1.7.0",

--- a/src/app-command.ts
+++ b/src/app-command.ts
@@ -5,7 +5,7 @@ import Base from './command-base'
 export default abstract class AppCommand extends Base {
   static flags = {
     defaults: flags.boolean({description: 'use defaults for every setting'}),
-    options: flags.string({description: '(yarn|typescript|tslint|mocha)'}),
+    options: flags.string({description: '(yarn|pnpm|typescript|tslint|mocha)'}),
     force: flags.boolean({description: 'overwrite existing files'}),
   }
   static args = [


### PR DESCRIPTION
Allow installing dependencies with [pnpm](https://github.com/pnpm/pnpm) (fixes https://github.com/oclif/oclif/issues/227).

Note that this PR adds a dependency on [dargs](https://github.com/sindresorhus/dargs), which shouldn't be too bad since it's already a dependency of Yeoman. We need dargs to convert the options object to flags for pnpm, which is what Yeoman does internally when invoking `npmInstall` or `yarnInstall`.

(A couple of upstream PR's have been opened on Yeoman's generator package to introduce a `pnpmInstall` method, which would remove the need for installing dargs here, but it's unclear whether the maintainers will merge either: https://github.com/yeoman/generator/pull/1067, https://github.com/yeoman/generator/pull/1107)

CC: @zkochan