### PR TITLE
fix: remove buildinfo on composite ts builds

### DIFF
--- a/src/generators/app.ts
+++ b/src/generators/app.ts
@@ -310,7 +310,7 @@ class App extends Generator {
       this.pjson.scripts.test = 'echo NO TESTS'
     }
     if (this.ts) {
-      this.pjson.scripts.prepack = nps.series(`${rmrf} lib`, 'tsc -b')
+      this.pjson.scripts.prepack = nps.series(`${rmrf} lib`, `${rmf} tsconfig.tsbuildinfo`, 'tsc -b')
     }
     if (['plugin', 'multi'].includes(this.type)) {
       this.pjson.scripts.prepack = nps.series(this.pjson.scripts.prepack, 'oclif-dev manifest', 'oclif-dev readme')


### PR DESCRIPTION
If you are building locally using `npm version` then `npm publish` the lib folder doesn't show up in the published package.
This occurs because we are doing `rm -rf lib` on prepack in addition to having `"composite": true` in tsconfig.  The lib folder won't rebuild locally until you also remove tsconfig.tsbuildinfo file, so having this be a part of the 'prepack' step will solve this issue locally.

I have a feeling that CI builds didn't see this since they are likely being run against a fresh repo.