### PR TITLE
Update license template copyright year

### DIFF
--- a/templates/LICENSE.mit
+++ b/templates/LICENSE.mit
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 <%- pjson.author %>
+Copyright (c) 2019 <%- pjson.author %>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
There might be a better fix for #240 that makes the year dynamic, but this may work for a quick and temporary solution.