### PR TITLE
set "composite": false

### DIFF
--- a/templates/tsconfig.json
+++ b/templates/tsconfig.json
@@ -6,8 +6,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "target": "es2017",
-    "composite": true
+    "target": "es2017"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
See https://spectrum.chat/oclif/general/lib-folder-is-not-found-in-npm-publish-component~b74ef8d9-96c4-46bd-9893-7cdcca8542fb

Fixes https://github.com/oclif/oclif/issues/246