### PR TITLE
fix: use correct path separators in travis.yml template

### DIFF
--- a/templates/travis.yml.ejs
+++ b/templates/travis.yml.ejs
@@ -6,15 +6,15 @@ cache: <%- yarn ? 'yarn' : 'npm' %>
 
 script:
 <%_ if (type === 'single' || type === 'multi') { _%>
-  - .\bin\run --version
-  - .\bin\run --help
+  - ./bin/run --version
+  - ./bin/run --help
 <%_ } else if (type === 'plugin') { _%>
-  - .\bin\run --help
+  - ./bin/run --help
 <%_ } _%>
   - <%- yarn ? 'yarn' : 'npm' %> run test
 
 <% if(mocha && codecov) { %>
 after_success:
-  - .\node_modules\.bin\nyc report --reporter text-lcov > coverage.lcov
+  - ./node_modules/.bin/nyc report --reporter text-lcov > coverage.lcov
   - bash < (curl -s https://codecov.io/bash)
 <% } %>


### PR DESCRIPTION
fixes #239 