### PR TITLE
fix: respect cache on promote

### DIFF
--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -61,6 +61,7 @@ export default class Promote extends Command {
           CopySource: copySource,
           Key: key,
           CacheControl: maxAge,
+          MetadataDirective: 'REPLACE'
         },
       )
 
@@ -82,6 +83,7 @@ export default class Promote extends Command {
           CopySource: versionedTarGzKey,
           Key: unversionedTarGzKey,
           CacheControl: maxAge,
+          MetadataDirective: 'REPLACE'
         },
       )
 
@@ -104,6 +106,7 @@ export default class Promote extends Command {
             CopySource: versionedTarXzKey,
             Key: unversionedTarXzKey,
             CacheControl: maxAge,
+            MetadataDirective: 'REPLACE'
           },
         )
       }
@@ -123,6 +126,7 @@ export default class Promote extends Command {
           CopySource: darwinCopySource,
           Key: darwinKey,
           CacheControl: maxAge,
+          MetadataDirective: 'REPLACE'
         },
       )
     }
@@ -173,6 +177,7 @@ export default class Promote extends Command {
             CopySource: debCopySource,
             Key: debKey,
             CacheControl: maxAge,
+            MetadataDirective: 'REPLACE'
           },
         )
       }

--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -61,7 +61,7 @@ export default class Promote extends Command {
           CopySource: copySource,
           Key: key,
           CacheControl: maxAge,
-          MetadataDirective: 'REPLACE'
+          MetadataDirective: 'REPLACE',
         },
       )
 
@@ -83,7 +83,7 @@ export default class Promote extends Command {
           CopySource: versionedTarGzKey,
           Key: unversionedTarGzKey,
           CacheControl: maxAge,
-          MetadataDirective: 'REPLACE'
+          MetadataDirective: 'REPLACE',
         },
       )
 
@@ -106,7 +106,7 @@ export default class Promote extends Command {
             CopySource: versionedTarXzKey,
             Key: unversionedTarXzKey,
             CacheControl: maxAge,
-            MetadataDirective: 'REPLACE'
+            MetadataDirective: 'REPLACE',
           },
         )
       }
@@ -126,7 +126,7 @@ export default class Promote extends Command {
           CopySource: darwinCopySource,
           Key: darwinKey,
           CacheControl: maxAge,
-          MetadataDirective: 'REPLACE'
+          MetadataDirective: 'REPLACE',
         },
       )
     }
@@ -177,7 +177,7 @@ export default class Promote extends Command {
             CopySource: debCopySource,
             Key: debKey,
             CacheControl: maxAge,
-            MetadataDirective: 'REPLACE'
+            MetadataDirective: 'REPLACE',
           },
         )
       }


### PR DESCRIPTION
explanation:

oclif upload tarballs with a 604800 max-age.  https://github.com/oclif/oclif/blob/711132e6a29ba82e370a5c90cc5059682c389a0f/src/commands/upload/tarballs.ts#L50

when we promote them, oclif uses copyobject which maintains those metadata/headers
```
$ aws s3api head-object --bucket dfc-data-production --key media/salesforce-cli/sfdx/channels/stable-rc/sfdx-win32-x86.tar.gz 
bytes   max-age=604800  40467686        application/gzip        "08bb2db16b33c5f0ba78e8b1232762ee"      2021-05-06T17:39:20+00:00       H924njmMRBpURBYiOh1DaQYS7OJcbVI8
$ aws s3api head-object --bucket dfc-data-production --key media/salesforce-cli/sfdx/channels/stable/sfdx-win32-x86.tar.gz 
bytes   max-age=604800  40466572        application/gzip        "c03e7193914a3883f0ebc8c15cdbb16a"      2021-05-06T16:33:15+00:00       WtlCN4zHUPoorQznsJKKIt4dB9vKN0H_
```

This PR adds the MetadataDirective option to tell it to update the CacheControl property.  Without this directive, that property is ignored (rather unintuitively!)

QA notes: if you've got access to the s3 buckets you can check the metadata on s3://dfc-data-production/media/salesforce-cli/sfdx/channels/cache-testing-shane/sfdx-linux-x64-buildmanifest via `aws s3api head-object --bucket dfc-data-production --key media/salesforce-cli/sfdx/channels/cache-testing-shane/sfdx-win32-x86.tar.gz`

or just inspect the headers for https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable-rc/sfdx-darwin-x64-buildmanifest 

running from local: replace the oclif property in package.json with 
```
"oclif": {
    "commands": "./lib/commands",
    "plugins": [
      "@oclif/plugin-help",
      "@oclif/plugin-warn-if-update-available",
      "@oclif/plugin-not-found"
    ],
    "bin": "sfdx",
    "dirname": "oclif",
    "macos": {
      "identifier": "com.oclif.cli",
      "sign": "Developer ID Installer: Heroku INC"
    },
    "update": {
      "autoupdate": {
        "rollout": 50,
        "debounce": 60
      },
      "node": {
        "version": "12.12.0"
      },
      "s3": {
        "bucket": "dfc-data-production",
        "folder": "media/salesforce-cli/sfdx",
        "acl": " ",
        "host": "https://developer.salesforce.com",
        "templates": {
          "target": {
            "baseDir": "sfdx-cli-v<%- version %>-<%- platform === 'win32' ? 'windows' : platform %>-<%- arch %>",
            "manifest": "media/salesforce-cli/sfdx-cli/channels/<%- channel %>/<%- platform === 'win32' ? 'windows' : platform %>-<%- arch %>",
            "versioned": "media/salesforce-cli/sfdx-cli/channels/<%- channel %>/sfdx-cli-v<%- version %>-<%- platform === 'win32' ? 'windows' : platform %>-<%- arch %>.tar.<%- ext %>"
          }
        }
      }
    },
    "topics": {
      "pack": {
        "description": "package an oclif CLI into installable artifacts"
      },
      "upload": {
        "description": "upload installable CLI artifacts to AWS S3"
      }
    }
  },
```
to use the `promote` command via bin/run