### PR TITLE
Sm/index of verions

### DIFF
--- a/src/aws.ts
+++ b/src/aws.ts
@@ -84,13 +84,19 @@ export default {
           else resolve(data)
         })
       }),
+      getObject: (options: S3.Types.GetObjectRequest) => new Promise<S3.GetObjectOutput>((resolve, reject) => {
+        debug('getObject', `s3://${options.Bucket}/${options.Key}`)
+        aws.s3.getObject(options, function (err, data) {
+          if (err) reject(err)
+          else resolve(data)
+        })
+      }),
     }
   },
 }
-
 // export const getObject = (options: S3.Types.GetObjectRequest) => new Promise<S3.GetObjectOutput>((resolve, reject) => {
 //   debug('getObject', `s3://${options.Bucket}/${options.Key}`)
-//   s3().getObject(options, (err, data) => {
+//   aws.s3().getObject(options, (err, data) => {
 //     if (err) reject(err)
 //     else resolve(data)
 //   })

--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -61,6 +61,7 @@ export default class Promote extends Command {
           CopySource: copySource,
           Key: key,
           CacheControl: maxAge,
+          MetadataDirective: 'REPLACE'
         },
       )
 
@@ -82,6 +83,7 @@ export default class Promote extends Command {
           CopySource: versionedTarGzKey,
           Key: unversionedTarGzKey,
           CacheControl: maxAge,
+          MetadataDirective: 'REPLACE'
         },
       )
 
@@ -104,6 +106,7 @@ export default class Promote extends Command {
             CopySource: versionedTarXzKey,
             Key: unversionedTarXzKey,
             CacheControl: maxAge,
+            MetadataDirective: 'REPLACE'
           },
         )
       }
@@ -123,6 +126,7 @@ export default class Promote extends Command {
           CopySource: darwinCopySource,
           Key: darwinKey,
           CacheControl: maxAge,
+          MetadataDirective: 'REPLACE'
         },
       )
     }
@@ -173,6 +177,7 @@ export default class Promote extends Command {
             CopySource: debCopySource,
             Key: debKey,
             CacheControl: maxAge,
+            MetadataDirective: 'REPLACE'
           },
         )
       }

--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -61,7 +61,7 @@ export default class Promote extends Command {
           CopySource: copySource,
           Key: key,
           CacheControl: maxAge,
-          MetadataDirective: 'REPLACE'
+          MetadataDirective: 'REPLACE',
         },
       )
 
@@ -83,7 +83,7 @@ export default class Promote extends Command {
           CopySource: versionedTarGzKey,
           Key: unversionedTarGzKey,
           CacheControl: maxAge,
-          MetadataDirective: 'REPLACE'
+          MetadataDirective: 'REPLACE',
         },
       )
 
@@ -106,7 +106,7 @@ export default class Promote extends Command {
             CopySource: versionedTarXzKey,
             Key: unversionedTarXzKey,
             CacheControl: maxAge,
-            MetadataDirective: 'REPLACE'
+            MetadataDirective: 'REPLACE',
           },
         )
       }
@@ -126,7 +126,7 @@ export default class Promote extends Command {
           CopySource: darwinCopySource,
           Key: darwinKey,
           CacheControl: maxAge,
-          MetadataDirective: 'REPLACE'
+          MetadataDirective: 'REPLACE',
         },
       )
     }
@@ -177,7 +177,7 @@ export default class Promote extends Command {
             CopySource: debCopySource,
             Key: debKey,
             CacheControl: maxAge,
-            MetadataDirective: 'REPLACE'
+            MetadataDirective: 'REPLACE',
           },
         )
       }

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,3 +41,29 @@ export namespace sort {
 }
 
 export const template = (context: any) => (t: string | undefined): string => _.template(t || '')(context)
+
+interface VersionsObject {
+  [key: string]: string;
+}
+
+export const sortVersionsObjectByKeysDesc = (input: VersionsObject): VersionsObject => {
+  const keys = Reflect.ownKeys(input).sort((a, b) => {
+    const splitA = (a as string).split('.').map(part => parseInt(part, 10))
+    const splitB = (b as string).split('.').map(part => parseInt(part, 10))
+    // sort by major
+    if (splitA[0] < splitB[0]) return 1
+    if (splitA[0] > splitB[0]) return -1
+    // sort by minor
+    if (splitA[1] < splitB[1]) return 1
+    if (splitA[1] > splitB[1]) return -1
+    // sort by patch
+    if (splitA[2] < splitB[2]) return 1
+    if (splitA[2] > splitB[2]) return -1
+    return 0
+  }) as string[]
+  const result: VersionsObject = {}
+  keys.forEach(key => {
+    result[key] = input[key]
+  })
+  return result
+}


### PR DESCRIPTION
adds an `--indexes` flag to the promote script.

This produces a json file at /versions for each arch/platform if it doesn't exist, and appends the promoted version to that file to an existing.  

The filename converts dots to dashes (blah-x64.exe becomes blah-x64-exe.json) to make the file friendlier to editors.

example:
```
$ aws s3 cp s3://dfc-data-production/media/salesforce-cli/sfdx/versions/sfdx-x64-exe.json /dev/stdout --quiet
{
  "7.103.0": "https://developer.salesforce.com/media/salesforce-cli/sfdx/versions/7.103.0/037481c/sfdx-v7.103.0-037481c-x64.exe",
  "7.102.0": "https://developer.salesforce.com/media/salesforce-cli/sfdx/versions/7.102.0/dd7aac3/sfdx-v7.102.0-dd7aac3-x64.exe",
  "7.101.0": "https://developer.salesforce.com/media/salesforce-cli/sfdx/versions/7.101.0/5e36989/sfdx-v7.101.0-5e36989-x64.exe",
  "7.100.0": "https://developer.salesforce.com/media/salesforce-cli/sfdx/versions/7.100.0/9d243d8/sfdx-v7.100.0-9d243d8-x64.exe",
  "7.99.0": "https://developer.salesforce.com/media/salesforce-cli/sfdx/versions/7.99.0/79e53c6/sfdx-v7.99.0-79e53c6-x64.exe",
  "7.98.0": "https://developer.salesforce.com/media/salesforce-cli/sfdx/versions/7.98.0/e361fce/sfdx-v7.98.0-e361fce-x64.exe"
}
``` 