### PR TITLE
build: use bin/dev to create manifest & readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,8 +121,8 @@
     "lint": "nps lint",
     "postpack": "rm .oclif.manifest.json",
     "posttest": "yarn run lint",
-    "prepack": "rm -rf lib && tsc && bin/run manifest",
-    "version": "bin/run readme && git add README.md",
+    "prepack": "rm -rf lib && tsc && bin/dev manifest",
+    "version": "bin/dev readme && git add README.md",
     "test": "nps test"
   },
   "publishConfig": {


### PR DESCRIPTION
Take a look at the release job, it is failing by trying to use `bin/dev` which only works if the lib is build. This uses bin/dev to create the manifest and readme for releasing.