### PR TITLE
Restore hook and command generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you have been using version 1 of the [`oclif` CLI](https://github.com/oclif/o
 
 ## New Commands
 
-Version 2 now includes all the commands in the [`oclif-dev` CLI](https://github.com/oclif/dev-cli) into `oclif`. This means that you can now use a single CLI for all your oclif needs. These commands include:
+Version 2 now includes all the commands from the [`oclif-dev` CLI](https://github.com/oclif/dev-cli). This means that you can now use a single CLI for all your oclif needs. These commands include:
 - `oclif manifest`
 - `oclif pack`
 - `oclif pack:deb`

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@
 oclif: Node.JS Open CLI Framework
 =================================
 
-[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/oclif)
 [![Version](https://img.shields.io/npm/v/oclif.svg)](https://npmjs.org/package/oclif)
 [![CircleCI](https://circleci.com/gh/oclif/oclif/tree/main.svg?style=shield)](https://circleci.com/gh/oclif/oclif/tree/main)
-[![Appveyor CI](https://ci.appveyor.com/api/projects/status/github/oclif/oclif?branch=main&svg=true)](https://ci.appveyor.com/project/heroku/oclif/branch/main)
 [![Downloads/week](https://img.shields.io/npm/dw/@oclif/command.svg)](https://npmjs.org/package/@oclif/core)
 [![License](https://img.shields.io/npm/l/oclif.svg)](https://github.com/oclif/oclif/blob/main/package.json)
 
@@ -17,6 +15,7 @@ oclif: Node.JS Open CLI Framework
 * [🚀 Getting Started Tutorial](#-getting-started-tutorial)
 * [✨ Features](#-features)
 * [📌 Requirements](#-requirements)
+* [📌 Migrating from V1](#-migrating-from-v1)
 * [🏗 Usage](#-usage)
 * [📚 Examples](#-examples)
 * [🔨 Commands](#-commands)
@@ -40,15 +39,14 @@ The [Getting Started tutorial](http://oclif.io/docs/introduction) is a step-by-s
 * **Flag/Argument parsing** - No CLI framework would be complete without a flag parser. We've built a custom one from years of experimentation that we feel consistently handles user input flexible enough for the user to be able to use the CLI in ways they expect, but without compromising strictness guarantees to the developer.
 * **Super Speed** - The overhead for running an oclif CLI command is almost nothing. [It requires very few dependencies](https://www.npmjs.com/package/@oclif/command?activeTab=dependencies) (only 35 dependencies in a minimal setup—including all transitive dependencies). Also, only the command to be executed will be required with node. So large CLIs with many commands will load equally as fast as a small one with a single command.
 * **CLI Generator** - Run a single command to scaffold out a fully functional CLI and get started quickly. See [Usage](#-usage) below.
-* **Testing Helpers** - We've put a lot of work into making commands easier to test and mock out stdout/stderr. The generator will automatically create [scaffolded tests](https://github.com/oclif/example-multi-ts/blob/master/test/commands/hello.test.ts).
+* **Testing Helpers** - We've put a lot of work into making commands easier to test and mock out stdout/stderr. The generator will automatically create [scaffolded tests](https://github.com/oclif/hello-world/blob/main/test/commands/hello.test.ts).
 * **Auto-documentation** - By default you can pass `--help` to the CLI to get help such as flag options and argument information. This information is also automatically placed in the README whenever the npm package of the CLI is published. See the [multi-command CLI example](https://github.com/oclif/example-multi-ts)
 * **Plugins** - Using [plugins](https://oclif.io/docs/plugins), users of the CLI can extend it with new functionality, a CLI can be split into modular components, and functionality can be shared amongst multiple CLIs. See [Building your own plugin](https://oclif.io/docs/plugins#building-your-own-plugin).
 * **Hooks** - Use lifecycle hooks to run functionality any time a CLI starts, or on custom triggers. Use this whenever custom functionality needs to be shared between various components of the CLI.
-* **TypeScript (or not)** - Everything in the core of oclif is written in TypeScript and the generator can build fully configured TypeScript CLIs or plain JavaScript CLIs. By virtue of static properties in TypeScript the syntax is a bit cleaner in TypeScript—but everything will work no matter which language you choose. If you use plugins support, the CLI will automatically use `ts-node` to run the plugins enabling you to use TypeScript with minimal-to-no boilerplate needed for any oclif CLI.
+* **TypeScript** - Everything in the core of oclif is written in TypeScript and the generator will build fully configured TypeScript CLIs. If you use plugins support, the CLI will automatically use `ts-node` to run the plugins enabling you to use TypeScript with minimal-to-no boilerplate needed for any oclif CLI.
 * **Auto-updating Installers** - oclif can package your CLI into [different installers](https://oclif.io/docs/releasing) that will not require the user to already have node installed on the machine. These can be made auto-updatable by using [plugin-update](https://github.com/oclif/plugin-update).
 * **Everything is Customizable** - Pretty much anything can be swapped out and replaced inside oclif if needed—including the arg/flag parser.
 * **Autocomplete** - Automatically include autocomplete for your CLI. This includes not only command names and flag names, but flag values as well. For example, it's possible to configure the Heroku CLI to have completions for Heroku app names:
-<!--* **Coming soon: man pages** - In addition to in-CLI help through `-help` and the README markdown help generation, the CLI can also automatically create man pages for all of its commands.-->
 
 ```
 $ heroku info --app=<tab><tab> # will complete with all the Heroku apps a user has in their account
@@ -56,7 +54,33 @@ $ heroku info --app=<tab><tab> # will complete with all the Heroku apps a user h
 
 # 📌 Requirements
 
-Currently, Node 8+ is supported. We support the [LTS versions](https://nodejs.org/en/about/releases) of Node. You can add the [node](https://www.npmjs.com/package/node) package to your CLI to ensure users are running a specific version of Node.
+Currently, Node 12+ is supported. We support the [LTS versions](https://nodejs.org/en/about/releases) of Node. You can add the [node](https://www.npmjs.com/package/node) package to your CLI to ensure users are running a specific version of Node.
+
+# 📌 Migrating from V1
+
+If you have been using version 1 of the [`oclif` CLI](https://github.com/oclif/oclif/tree/v1.18.4) there are some important differences to note when using the latest version.
+
+## Breaking Changes
+
+- `oclif multi`, `oclif plugin`, and `oclif single` have all been removed in favor of `oclif generate`, which generates an oclif based CLI using the [hello-world example repo](https://github.com/oclif/hello-world).
+  - The reason is that there's not enough of a meaningful difference between a "multi command cli", a "single command cli", and a "plugin" to justify the maintenance cost. The generated CLI can be easily used for any of those use cases.
+- `oclif hook` is now `oclif generate:hook`
+- `oclif command` is now `oclif generate:command`
+
+## New Commands
+
+Version 2 now includes all the commands in the [`oclif-dev` CLI](https://github.com/oclif/dev-cli) into `oclif`. This means that you can now use a single CLI for all your oclif needs. These commands include:
+- `oclif manifest`
+- `oclif pack`
+- `oclif pack:deb`
+- `oclif pack:macos`
+- `oclif pack:win`
+- `oclif upload` (formerly known as `oclif-dev publish`)
+- `oclif upload:deb` (formerly known as `oclif-dev publish:deb`)
+- `oclif upload:macos` (formerly known as `oclif-dev publish:macos`)
+- `oclif upload:win` (formerly known as `oclif-dev publish:win`)
+- `oclif readme`
+
 
 # 🏗 Usage
 
@@ -82,27 +106,40 @@ hello world from ./src/hello.js!
 
 # 📚 Examples
 
-* TypeScript
-  * [Multi-command CLI](https://github.com/oclif/example-multi-ts)
-  * [Single-command CLI](https://github.com/oclif/example-single-ts)
-  * [Multi-command CLI Plugin](https://github.com/oclif/example-plugin-ts)
+* [Hello-World](https://github.com/oclif/hello-world)
+* [Salesforce CLI](https://github.com/salesforcecli/cli)
+* [Heroku CLI](https://github.com/heroku/cli)
 
 # 🔨 Commands
 
 <!-- commands -->
-* [`oclif generate NAME`](#oclif-generate-name)
-* [`oclif help [COMMAND]`](#oclif-help-command)
-* [`oclif manifest [PATH]`](#oclif-manifest-path)
-* [`oclif pack:deb`](#oclif-packdeb)
-* [`oclif pack:macos`](#oclif-packmacos)
-* [`oclif pack:tarballs`](#oclif-packtarballs)
-* [`oclif pack:win`](#oclif-packwin)
-* [`oclif promote`](#oclif-promote)
-* [`oclif readme`](#oclif-readme)
-* [`oclif upload:deb`](#oclif-uploaddeb)
-* [`oclif upload:macos`](#oclif-uploadmacos)
-* [`oclif upload:tarballs`](#oclif-uploadtarballs)
-* [`oclif upload:win`](#oclif-uploadwin)
+- [oclif: Node.JS Open CLI Framework](#oclif-nodejs-open-cli-framework)
+- [🗒 Description](#-description)
+- [🚀 Getting Started Tutorial](#-getting-started-tutorial)
+- [✨ Features](#-features)
+- [📌 Requirements](#-requirements)
+- [📌 Migrating from V1](#-migrating-from-v1)
+  - [Breaking Changes](#breaking-changes)
+  - [New Commands](#new-commands)
+- [🏗 Usage](#-usage)
+- [📚 Examples](#-examples)
+- [🔨 Commands](#-commands)
+  - [`oclif generate NAME`](#oclif-generate-name)
+  - [`oclif help [COMMAND]`](#oclif-help-command)
+  - [`oclif manifest [PATH]`](#oclif-manifest-path)
+  - [`oclif pack:deb`](#oclif-packdeb)
+  - [`oclif pack:macos`](#oclif-packmacos)
+  - [`oclif pack:tarballs`](#oclif-packtarballs)
+  - [`oclif pack:win`](#oclif-packwin)
+  - [`oclif promote`](#oclif-promote)
+  - [`oclif readme`](#oclif-readme)
+  - [`oclif upload:deb`](#oclif-uploaddeb)
+  - [`oclif upload:macos`](#oclif-uploadmacos)
+  - [`oclif upload:tarballs`](#oclif-uploadtarballs)
+  - [`oclif upload:win`](#oclif-uploadwin)
+- [🏭 Related Repositories](#-related-repositories)
+- [🦔 Learn More](#-learn-more)
+- [📣 Feedback](#-feedback)
 
 ## `oclif generate NAME`
 
@@ -371,9 +408,7 @@ _See code: [src/commands/upload/win.ts](https://github.com/oclif/oclif/blob/v2.1
 
 # 🏭 Related Repositories
 
-* [@oclif/command](https://github.com/oclif/command) - Base command for oclif. This can be used directly without the generator.
-* [@oclif/config](https://github.com/oclif/config) - Most of the core setup for oclif lives here.
-* [@oclif/errors](https://github.com/oclif/errors) - Renders and logs errors from commands.
+* [@oclif/core](https://github.com/oclif/core) - Base library for oclif. This can be used directly without the generator.
 * [@oclif/cli-ux](https://github.com/oclif/cli-ux) - Library for common CLI UI utilities.
 * [@oclif/test](https://github.com/oclif/test) - Test helper for oclif.
 
@@ -384,4 +419,4 @@ _See code: [src/commands/upload/win.ts](https://github.com/oclif/oclif/blob/v2.1
 
 # 📣 Feedback
 
-If you have any suggestions or want to let us know what you think of oclif, send us a message at <heroku-cli@salesforce.com>
+If you have any suggestions or want to let us know what you think of oclif, send us a message at <alm-cli@salesforce.com>

--- a/bin/dev
+++ b/bin/dev
@@ -11,9 +11,8 @@ process.env.NODE_ENV = 'development'
 require('ts-node').register({project})
 
 // In dev mode, always show stack traces
-// Waiting for https://github.com/oclif/core/pull/147
-// oclif.settings.debug = true;
-oclif.settings.disableJsonFlag = true
+oclif.settings.debug = true;
+
 
 // Start the CLI
 oclif.run().then(oclif.flush).catch(oclif.Errors.handle)

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     ],
     "bin": "oclif",
     "dirname": "oclif",
+    "topicSeparator": " ",
     "macos": {
       "identifier": "com.oclif.cli",
       "sign": "Developer ID Installer: Heroku INC"

--- a/src/commands/generate/command.ts
+++ b/src/commands/generate/command.ts
@@ -1,0 +1,26 @@
+import CommandBase from './../../command-base'
+import {Flags} from '@oclif/core'
+
+export default class GenerateCommand extends CommandBase {
+  static description = `generate a new CLI
+This will clone the template repo 'oclif/hello-world' and update package properties`
+
+  static flags = {
+    defaults: Flags.boolean({description: 'use defaults for every setting'}),
+    force: Flags.boolean({description: 'overwrite existing files'}),
+  }
+
+  static args = [
+    {name: 'name', description: 'name of command', required: true},
+  ]
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(GenerateCommand)
+
+    await super.generate('command', {
+      name: args.name,
+      defaults: flags.defaults,
+      force: flags.force,
+    })
+  }
+}

--- a/src/commands/generate/command.ts
+++ b/src/commands/generate/command.ts
@@ -5,7 +5,6 @@ export default class GenerateCommand extends CommandBase {
   static description = 'add a command to an existing CLI or plugin'
 
   static flags = {
-    defaults: Flags.boolean({description: 'use defaults for every setting'}),
     force: Flags.boolean({description: 'overwrite existing files'}),
   }
 
@@ -18,7 +17,6 @@ export default class GenerateCommand extends CommandBase {
 
     await super.generate('command', {
       name: args.name,
-      defaults: flags.defaults,
       force: flags.force,
     })
   }

--- a/src/commands/generate/hook.ts
+++ b/src/commands/generate/hook.ts
@@ -5,7 +5,6 @@ export default class GenerateHook extends CommandBase {
   static description = 'add a hook to an existing CLI or plugin'
 
   static flags = {
-    defaults: Flags.boolean({description: 'use defaults for every setting'}),
     force: Flags.boolean({description: 'overwrite existing files'}),
     event: Flags.string({description: 'event to run hook on', default: 'init'}),
   }
@@ -20,7 +19,6 @@ export default class GenerateHook extends CommandBase {
     await super.generate('hook', {
       name: args.name,
       event: flags.event,
-      defaults: flags.defaults,
       force: flags.force,
     })
   }

--- a/src/commands/generate/hook.ts
+++ b/src/commands/generate/hook.ts
@@ -1,23 +1,25 @@
 import CommandBase from './../../command-base'
 import {Flags} from '@oclif/core'
 
-export default class GenerateCommand extends CommandBase {
-  static description = 'add a command to an existing CLI or plugin'
+export default class GenerateHook extends CommandBase {
+  static description = 'add a hook to an existing CLI or plugin'
 
   static flags = {
     defaults: Flags.boolean({description: 'use defaults for every setting'}),
     force: Flags.boolean({description: 'overwrite existing files'}),
+    event: Flags.string({description: 'event to run hook on', default: 'init'}),
   }
 
   static args = [
-    {name: 'name', description: 'name of command', required: true},
+    {name: 'name', description: 'name of hook (snake_case)', required: true},
   ]
 
   async run(): Promise<void> {
-    const {args, flags} = await this.parse(GenerateCommand)
+    const {args, flags} = await this.parse(GenerateHook)
 
-    await super.generate('command', {
+    await super.generate('hook', {
       name: args.name,
+      event: flags.event,
       defaults: flags.defaults,
       force: flags.force,
     })

--- a/src/generators/cli.ts
+++ b/src/generators/cli.ts
@@ -97,7 +97,7 @@ export default class CLI extends Generator {
       repository,
       ...this.pjson,
       engines: {
-        node: '>=8.0.0',
+        node: '>=12.0.0',
         ...this.pjson.engines,
       },
       options: this.options,

--- a/src/generators/cli.ts
+++ b/src/generators/cli.ts
@@ -71,7 +71,7 @@ export default class CLI extends Generator {
 
     this.log(yosay(`${msg} Version: ${version}`))
 
-    execSync(`git clone https://github.com/oclif/hello-world.git ${path.resolve(this.name)}`)
+    execSync(`git clone https://github.com/oclif/hello-world.git "${path.resolve(this.name)}"`)
     fs.rmSync(`${path.resolve(this.name, '.git')}`, {recursive: true})
 
     this.destinationRoot(path.resolve(this.name))

--- a/src/generators/cli.ts
+++ b/src/generators/cli.ts
@@ -18,7 +18,7 @@ try {
   hasYarn = true
 } catch {}
 
-class App extends Generator {
+export default class CLI extends Generator {
   options: {
     defaults?: boolean;
     yarn: boolean;
@@ -72,7 +72,7 @@ class App extends Generator {
     this.log(yosay(`${msg} Version: ${version}`))
 
     execSync(`git clone https://github.com/oclif/hello-world.git ${path.resolve(this.name)}`)
-    fs.rmdirSync(`${path.resolve(this.name, '.git')}`, {recursive: true})
+    fs.rmSync(`${path.resolve(this.name, '.git')}`, {recursive: true})
 
     this.destinationRoot(path.resolve(this.name))
     process.chdir(this.destinationRoot())
@@ -255,5 +255,3 @@ class App extends Generator {
     .join('\n') + '\n'
   }
 }
-
-export = App

--- a/src/generators/command.ts
+++ b/src/generators/command.ts
@@ -1,0 +1,61 @@
+import * as _ from 'lodash'
+import * as path from 'path'
+import * as Generator from 'yeoman-generator'
+import yosay = require('yosay')
+
+const {version} = require('../../package.json')
+
+export interface Options extends Generator.GeneratorOptions {
+  name: string;
+  defaults?: boolean;
+  force?: boolean;
+}
+
+export interface PackageJson {
+  name: string;
+  devDependencies: Record<string, string>;
+  dependencies: Record<string, string>;
+  oclif: {
+    bin: string;
+    dirname: string;
+  };
+}
+
+export default class Command extends Generator {
+  public options: Options
+  public pjson!: PackageJson
+
+  constructor(args: string | string[], opts: Options) {
+    super(args, opts)
+    this.options = {
+      name: opts.name,
+      defaults: opts.defaults,
+      force: opts.force,
+    }
+  }
+
+  private hasMocha(): boolean {
+    return Boolean(this.pjson.devDependencies?.mocha)
+  }
+
+  public async prompting(): Promise<void> {
+    this.pjson = this.fs.readJSON('package.json') as unknown as PackageJson
+    if (!this.pjson) throw new Error('not in a project directory')
+    this.pjson.oclif = this.pjson.oclif || {}
+    this.log(yosay(`Adding a command to ${this.pjson.name} Version: ${version}`))
+  }
+
+  public writing(): void {
+    const cmdPath = this.options.name.split(':').join('/')
+    this.sourceRoot(path.join(__dirname, '../../templates'))
+    let bin = this.pjson.oclif.bin || this.pjson.oclif.dirname || this.pjson.name
+    if (bin.includes('/')) bin = bin.split('/').pop()!
+    const cmd = `${bin} ${this.options.name}`
+    const commandPath = this.destinationPath(`src/commands/${cmdPath}.ts`)
+    const opts = {...this.options, bin, cmd, _, type: 'command', path: commandPath}
+    this.fs.copyTpl(this.templatePath('src/command.ts.ejs'), commandPath, opts)
+    if (this.hasMocha()) {
+      this.fs.copyTpl(this.templatePath('test/command.test.ts.ejs'), this.destinationPath(`test/commands/${cmdPath}.test.ts`), opts)
+    }
+  }
+}

--- a/src/generators/command.ts
+++ b/src/generators/command.ts
@@ -2,30 +2,15 @@ import * as _ from 'lodash'
 import * as path from 'path'
 import * as Generator from 'yeoman-generator'
 import yosay = require('yosay')
+import {GeneratorOptions, PackageJson} from '../types'
 
 const {version} = require('../../package.json')
 
-export interface Options extends Generator.GeneratorOptions {
-  name: string;
-  defaults?: boolean;
-  force?: boolean;
-}
-
-export interface PackageJson {
-  name: string;
-  devDependencies: Record<string, string>;
-  dependencies: Record<string, string>;
-  oclif: {
-    bin: string;
-    dirname: string;
-  };
-}
-
 export default class Command extends Generator {
-  public options: Options
+  public options: GeneratorOptions
   public pjson!: PackageJson
 
-  constructor(args: string | string[], opts: Options) {
+  constructor(args: string | string[], opts: GeneratorOptions) {
     super(args, opts)
     this.options = {
       name: opts.name,

--- a/src/generators/hook.ts
+++ b/src/generators/hook.ts
@@ -1,0 +1,51 @@
+import * as _ from 'lodash'
+import * as path from 'path'
+import * as Generator from 'yeoman-generator'
+import yosay = require('yosay')
+import {GeneratorOptions, PackageJson} from '../types'
+
+const {version} = require('../../package.json')
+
+export interface Options extends GeneratorOptions {
+  event: string;
+}
+
+export default class Hook extends Generator {
+  public pjson!: PackageJson
+
+  constructor(args: string | string[], public options: Options) {
+    super(args, options)
+  }
+
+  private hasMocha(): boolean {
+    return Boolean(this.pjson.devDependencies?.mocha)
+  }
+
+  public async prompting(): Promise<void> {
+    this.pjson = this.fs.readJSON('package.json') as unknown as PackageJson
+    this.pjson.oclif = this.pjson.oclif || {}
+    if (!this.pjson) throw new Error('not in a project directory')
+    this.log(yosay(`Adding a ${this.options.event} hook to ${this.pjson.name} Version: ${version}`))
+  }
+
+  public writing(): void {
+    this.sourceRoot(path.join(__dirname, '../../templates'))
+    this.fs.copyTpl(this.templatePath('src/hook.ts.ejs'), this.destinationPath(`src/hooks/${this.options.event}/${this.options.name}.ts`), this)
+    if (this.hasMocha()) {
+      this.fs.copyTpl(this.templatePath('test/hook.test.ts.ejs'), this.destinationPath(`test/hooks/${this.options.event}/${this.options.name}.test.ts`), this)
+    }
+
+    this.pjson.oclif = this.pjson.oclif || {}
+    this.pjson.oclif.hooks = this.pjson.oclif.hooks || {}
+    const hooks = this.pjson.oclif.hooks
+    const p = `./src/hooks/${this.options.event}/${this.options.name}`
+    if (hooks[this.options.event]) {
+      hooks[this.options.event] = _.castArray(hooks[this.options.event])
+      hooks[this.options.event] = hooks[this.options.event].concat(p)
+    } else {
+      this.pjson.oclif.hooks[this.options.event] = p
+    }
+
+    this.fs.writeJSON(this.destinationPath('./package.json'), this.pjson)
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,18 @@
+import * as Generator from 'yeoman-generator'
+
+export interface PackageJson {
+  name: string;
+  devDependencies: Record<string, string>;
+  dependencies: Record<string, string>;
+  oclif: {
+    bin: string;
+    dirname: string;
+    hooks: Record<string, string | string[]>;
+  };
+}
+
+export interface GeneratorOptions extends Generator.GeneratorOptions {
+  name: string;
+  defaults?: boolean;
+  force?: boolean;
+}

--- a/templates/src/command.ts.ejs
+++ b/templates/src/command.ts.ejs
@@ -1,0 +1,29 @@
+import {Command, Flags} from '@oclif/core'
+<%_ const klass = _.upperFirst(_.camelCase(name)) _%>
+
+export default class <%- klass %> extends Command {
+  static description = 'describe the command here'
+
+  static examples = [
+    '<%%= config.bin %> <%%= command.id %>',
+  ]
+
+  static flags = {
+    // flag with a value (-n, --name=VALUE)
+    name: Flags.string({char: 'n', description: 'name to print'}),
+    // flag with no value (-f, --force)
+    force: Flags.boolean({char: 'f'}),
+  }
+
+  static args = [{name: 'file'}]
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(<%- klass %>)
+
+    const name = flags.name ?? 'world'
+    this.log(`hello ${name} from <%- path.replace(/\\/g, '\\\\') %>`)
+    if (args.file && flags.force) {
+      this.log(`you input --force and --file: ${args.file}`)
+    }
+  }
+}

--- a/templates/src/hook.ts.ejs
+++ b/templates/src/hook.ts.ejs
@@ -1,0 +1,7 @@
+import {Hook} from '@oclif/core'
+
+const hook: Hook<'<%- options.event %>'> = async function (opts) {
+  process.stdout.write(`example hook running ${opts.id}\n`)
+}
+
+export default hook

--- a/templates/test/command.test.ts.ejs
+++ b/templates/test/command.test.ts.ejs
@@ -1,0 +1,29 @@
+import {expect, test} from '@oclif/test'
+<%_ if (type === 'single') { _%>
+
+import cmd = require('../src')
+<%_ } _%>
+
+describe('<%- name %>', () => {
+  test
+  .stdout()
+<%_ if (type === 'single') { _%>
+  .do(() => cmd.run([]))
+<%_ } else { _%>
+  .command(['<%- name %>'])
+<%_ } _%>
+  .it('runs hello', ctx => {
+    expect(ctx.stdout).to.contain('hello world')
+  })
+
+  test
+  .stdout()
+<%_ if (type === 'single') { _%>
+  .do(() => cmd.run(['--name', 'jeff']))
+<%_ } else { _%>
+  .command(['<%- name %>', '--name', 'jeff'])
+<%_ } _%>
+  .it('runs hello --name jeff', ctx => {
+    expect(ctx.stdout).to.contain('hello jeff')
+  })
+})

--- a/templates/test/command.test.ts.ejs
+++ b/templates/test/command.test.ts.ejs
@@ -1,28 +1,16 @@
 import {expect, test} from '@oclif/test'
-<%_ if (type === 'single') { _%>
-
-import cmd = require('../src')
-<%_ } _%>
 
 describe('<%- name %>', () => {
   test
   .stdout()
-<%_ if (type === 'single') { _%>
-  .do(() => cmd.run([]))
-<%_ } else { _%>
   .command(['<%- name %>'])
-<%_ } _%>
   .it('runs hello', ctx => {
     expect(ctx.stdout).to.contain('hello world')
   })
 
   test
   .stdout()
-<%_ if (type === 'single') { _%>
-  .do(() => cmd.run(['--name', 'jeff']))
-<%_ } else { _%>
   .command(['<%- name %>', '--name', 'jeff'])
-<%_ } _%>
   .it('runs hello --name jeff', ctx => {
     expect(ctx.stdout).to.contain('hello jeff')
   })

--- a/templates/test/hook.test.ts.ejs
+++ b/templates/test/hook.test.ts.ejs
@@ -1,0 +1,9 @@
+import {expect, test} from '@oclif/test'
+
+describe('hooks', () => {
+  test
+  .stdout()
+  .hook('init', {id: 'mycommand'})
+  .do(output => expect(output.stdout).to.contain('example hook running mycommand'))
+  .it('shows a message')
+})


### PR DESCRIPTION
- Restores the `hook` and `command` commands from v1 as `generate:hook` and `generate:command`, respectively. 
- Updates REAMDE with notes about migrating from v1 to v2

Fixes #767 

@W-10386078@