### PR TITLE
Fix deprecation warning for `fs.rmdirSync`

### DIFF
--- a/src/generators/cli.ts
+++ b/src/generators/cli.ts
@@ -72,7 +72,7 @@ class App extends Generator {
     this.log(yosay(`${msg} Version: ${version}`))
 
     execSync(`git clone https://github.com/oclif/hello-world.git ${path.resolve(this.name)}`)
-    fs.rmdirSync(`${path.resolve(this.name, '.git')}`, {recursive: true})
+    fs.rmSync(`${path.resolve(this.name, '.git')}`, {recursive: true, force: true})
 
     this.destinationRoot(path.resolve(this.name))
     process.chdir(this.destinationRoot())


### PR DESCRIPTION
Fixes this warning:

![image](https://user-images.githubusercontent.com/25503371/148749336-c6965f0d-6548-4e57-9f56-393f6108c8d3.png)

Regarding: https://nodejs.org/dist/latest-v17.x/docs/api/deprecations.html#DEP0147

Tests are passing.