### PR TITLE
Fix tarball packing in paths with spaces

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -17,7 +17,7 @@ const pack = async (from: string, to: string) => {
   log(`packing tarball from ${qq.prettifyPaths(from)} to ${qq.prettifyPaths(to)}`)
   await (to.endsWith('gz') ?
     qq.x('tar', ['czf', to, path.basename(from)]) :
-    qq.x(`tar c ${path.basename(from)} | xz > ${to}`))
+    qq.x(`tar c "${path.basename(from)}" | xz > "${to}"`))
   qq.cd(prevCwd)
 }
 
@@ -39,7 +39,7 @@ export async function build(c: BuildConfig, options: {
     tarball = path.basename(tarball)
     tarball = qq.join([c.workspace(), tarball])
     qq.cd(c.workspace())
-    await qq.x(`tar -xzf ${tarball}`)
+    await qq.x(`tar -xzf "${tarball}"`)
     // eslint-disable-next-line no-await-in-loop
     for (const f of await qq.ls('package', {fullpath: true})) await qq.mv(f, '.')
     await qq.rm('package', tarball, 'bin/run.cmd')

--- a/src/tarballs/node.ts
+++ b/src/tarballs/node.ts
@@ -47,7 +47,7 @@ export async function fetchNodeBinary({nodeVersion, output, platform, arch, tmp}
     const basedir = path.dirname(tarball)
     await qq.mkdirp(basedir)
     await qq.download(url, tarball)
-    await qq.x(`grep ${path.basename(tarball)} ${shasums} | shasum -a 256 -c -`, {cwd: basedir})
+    await qq.x(`grep "${path.basename(tarball)}" "${shasums}" | shasum -a 256 -c -`, {cwd: basedir})
   }
 
   const extract = async () => {
@@ -58,11 +58,11 @@ export async function fetchNodeBinary({nodeVersion, output, platform, arch, tmp}
     await qq.mkdirp(path.dirname(cache))
     if (platform === 'win32') {
       qq.pushd(nodeTmp)
-      await qq.x(`7z x -bd -y ${tarball} > /dev/null`)
+      await qq.x(`7z x -bd -y "${tarball}" > /dev/null`)
       await qq.mv([nodeBase, 'node.exe'], cache)
       qq.popd()
     } else {
-      await qq.x(`tar -C ${tmp}/node -xJf ${tarball}`)
+      await qq.x(`tar -C "${tmp}/node" -xJf "${tarball}"`)
       await qq.mv([nodeTmp, nodeBase, 'bin/node'], cache)
     }
   }


### PR DESCRIPTION
This replaces https://github.com/oclif/dev-cli/pull/416.

This PR just adds quotes around a few raw paths used during tarball packing, ensuring that these steps work when run in a path containing spaces.

I've tested this in my project, and everything now seems to build correctly when running `oclif pack tarballs`.