### PR TITLE
feat: Add support to build darwin-arm64 for `oclif pack macos`

### DIFF
--- a/src/commands/pack/macos.ts
+++ b/src/commands/pack/macos.ts
@@ -1,7 +1,7 @@
 import {Command, Flags} from '@oclif/core'
 import {Interfaces} from '@oclif/core'
 
-import * as path from 'path'
+import * as _ from 'lodash'
 import * as qq from 'qqjs'
 
 import * as Tarballs from '../../tarballs'
@@ -145,35 +145,44 @@ the CLI should already exist in a directory named after the CLI that is the root
     const macos = c.macos
     const packageIdentifier = macos.identifier
     await Tarballs.build(buildConfig, {platform: 'darwin', pack: false, tarball: flags.tarball})
-    const templateKey = templateShortKey('macos', {bin: config.bin, version: config.version, sha: buildConfig.gitSha})
-    const dist = buildConfig.dist(`macos/${templateKey}`)
-    await qq.emptyDir(path.dirname(dist))
     const scriptsDir = qq.join(buildConfig.tmp, 'macos/scripts')
-    const rootDir = buildConfig.workspace({platform: 'darwin', arch: 'x64'})
-    const writeScript = async (script: 'preinstall' | 'postinstall' | 'uninstall') => {
-      const path = script === 'uninstall' ? [rootDir, 'bin'] : [scriptsDir]
-      path.push(script)
-      await qq.write(path, scripts[script](config, flags['additional-cli']))
-      await qq.chmod(path, 0o755)
+    await qq.emptyDir(buildConfig.dist('macos'))
+    
+    const build = async (arch: Interfaces.ArchTypes) => {
+      const templateKey = templateShortKey('macos', {bin: config.bin, version: config.version, sha: buildConfig.gitSha})
+      const dist = buildConfig.dist(`macos/${templateKey}`)
+      const rootDir = buildConfig.workspace({platform: 'darwin', arch})
+      const writeScript = async (script: 'preinstall' | 'postinstall' | 'uninstall') => {
+        const path = script === 'uninstall' ? [rootDir, 'bin'] : [scriptsDir]
+        path.push(script)
+        await qq.write(path, scripts[script](config, flags['additional-cli']))
+        await qq.chmod(path, 0o755)
+      }
+
+      await writeScript('preinstall')
+      await writeScript('postinstall')
+      await writeScript('uninstall')
+      /* eslint-disable array-element-newline */
+      const args = [
+        '--root', rootDir,
+        '--identifier', packageIdentifier,
+        '--version', config.version,
+        '--install-location', `/usr/local/lib/${config.dirname}`,
+        '--scripts', scriptsDir,
+      ]
+      /* eslint-enable array-element-newline */
+      if (macos.sign) {
+        args.push('--sign', macos.sign)
+      } else this.debug('Skipping macOS pkg signing')
+      if (process.env.OSX_KEYCHAIN) args.push('--keychain', process.env.OSX_KEYCHAIN)
+      args.push(dist)
+      await qq.x('pkgbuild', args as string[])
     }
 
-    await writeScript('preinstall')
-    await writeScript('postinstall')
-    await writeScript('uninstall')
-    /* eslint-disable array-element-newline */
-    const args = [
-      '--root', rootDir,
-      '--identifier', packageIdentifier,
-      '--version', config.version,
-      '--install-location', `/usr/local/lib/${config.dirname}`,
-      '--scripts', scriptsDir,
-    ]
-    /* eslint-enable array-element-newline */
-    if (macos.sign) {
-      args.push('--sign', macos.sign)
-    } else this.debug('Skipping macOS pkg signing')
-    if (process.env.OSX_KEYCHAIN) args.push('--keychain', process.env.OSX_KEYCHAIN)
-    args.push(dist)
-    await qq.x('pkgbuild', args as string[])
+    const arches = _.uniq(buildConfig.targets
+      .filter(t => t.platform === 'darwin')
+      .map(t => t.arch))
+      // eslint-disable-next-line no-await-in-loop
+      for (const a of arches) await build(a)
   }
 }


### PR DESCRIPTION
When packing the macOS `.pkg` is currently only doing it for `darwin-x64`, with this change it will build for `darwin-arm64` if the command is run on a M1 machine.