### PR TITLE
fix: Add arch to macos pkg file

### DIFF
--- a/src/upload-util.ts
+++ b/src/upload-util.ts
@@ -34,7 +34,7 @@ export function templateShortKey(
     unversioned: '<%- bin %>-<%- platform %>-<%- arch %><%- ext %>',
     versioned: '<%- bin %>-v<%- version %>-<%- sha %>-<%- platform %>-<%- arch %><%- ext %>',
     manifest: '<%- bin %>-v<%- version %>-<%- sha %>-<%- platform %>-<%- arch %>-buildmanifest',
-    macos: '<%- bin %>-v<%- version %>-<%- sha %>.pkg',
+    macos: '<%- bin %>-v<%- version %>-<%- sha %>-<%- arch %>.pkg',
     win32: '<%- bin %>-v<%- version %>-<%- sha %>-<%- arch %>.exe',
     deb: '<%- bin %>_<%- versionShaRevision %>_<%- arch %>.deb',
   }


### PR DESCRIPTION
I just realised from a previous PR https://github.com/oclif/oclif/pull/846 that the `arch` parameter was ignored when building the output filename for macos. 🤦  Packing for x64 and arm64 was overwriting the first file built.