### PR TITLE
Fix `oclif pack macos`

### DIFF
--- a/src/commands/pack/macos.ts
+++ b/src/commands/pack/macos.ts
@@ -147,9 +147,6 @@ the CLI should already exist in a directory named after the CLI that is the root
     const macos = c.macos
     const packageIdentifier = macos.identifier
     await Tarballs.build(buildConfig, {platform: 'darwin', pack: false, tarball: flags.tarball})
-    const templateKey = templateShortKey('macos', {bin: config.bin, version: config.version, sha: buildConfig.gitSha})
-    const dist = buildConfig.dist(`macos/${templateKey}`)
-    await qq.emptyDir(path.dirname(dist))
     const scriptsDir = qq.join(buildConfig.tmp, 'macos/scripts')
     await qq.emptyDir(buildConfig.dist('macos'))
 


### PR DESCRIPTION
This removes outdated code that was accidentally re-introduced by bad conflict resolution on a merge.

The code was re-added to main when this commit, https://github.com/oclif/oclif/commit/e5b68af8510b0419ec48d76087ed0bec61fc81ad, to revert some changes was added. This caused merge conflicts with the PR that added the M1 functionality, https://github.com/oclif/oclif/pull/849, and those were incorrectly resolved when it was merged.


Fixes #865 