### PR TITLE
fix: Update hooks generator to point to ./dist/hooks instead of ./src/hooks

### DIFF
--- a/src/generators/hook.ts
+++ b/src/generators/hook.ts
@@ -38,7 +38,7 @@ export default class Hook extends Generator {
     this.pjson.oclif = this.pjson.oclif || {}
     this.pjson.oclif.hooks = this.pjson.oclif.hooks || {}
     const hooks = this.pjson.oclif.hooks
-    const p = `./src/hooks/${this.options.event}/${this.options.name}`
+    const p = `./dist/hooks/${this.options.event}/${this.options.name}`
     if (hooks[this.options.event]) {
       hooks[this.options.event] = _.castArray(hooks[this.options.event])
       hooks[this.options.event] = hooks[this.options.event].concat(p)


### PR DESCRIPTION
This will resolve https://github.com/oclif/oclif/issues/902

This does not change where the hooks are saved to as that is done on line 33, it only updates the path in package.json for the end user's cli being built