### PR TITLE
fix: add toc tag to readme command description

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -23,6 +23,8 @@ The readme must have any of the following tags inside of it for it to be replace
 <!-- usage -->
 # Commands
 <!-- commands -->
+# Table of contents
+<!-- toc -->
 
 Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
 `


### PR DESCRIPTION
This PR adds the missing `toc` tag to the description for the `readme` command.