### PR TITLE
feat: add `--aliases` flag for readme command

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -33,8 +33,6 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
     aliases: Flags.boolean({description: 'include aliases in the command list', allowNo: true, default: true }),
   }
 
-  static aliases = ['rdm']
-
   private HelpClass!: HelpBaseDerived
 
   async run(): Promise<void> {

--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -30,7 +30,10 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
   static flags = {
     dir: Flags.string({description: 'output directory for multi docs', default: 'docs', required: true}),
     multi: Flags.boolean({description: 'create a different markdown page for each topic'}),
+    aliases: Flags.boolean({description: 'include aliases in the command list', allowNo: true, default: true }),
   }
+
+  static aliases = ['rdm']
 
   private HelpClass!: HelpBaseDerived
 
@@ -55,6 +58,7 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
 
     let commands = config.commands
     .filter(c => !c.hidden && c.pluginType === 'core')
+    .filter(c => flags.aliases? true : !c.aliases.includes(c.id))
     .map(c => c.id === '.' ? {...c, id: ''} : c)
 
     this.debug('commands:', commands.map(c => c.id).length)

--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -30,7 +30,7 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
   static flags = {
     dir: Flags.string({description: 'output directory for multi docs', default: 'docs', required: true}),
     multi: Flags.boolean({description: 'create a different markdown page for each topic'}),
-    aliases: Flags.boolean({description: 'include aliases in the command list', allowNo: true, default: true }),
+    aliases: Flags.boolean({description: 'include aliases in the command list', allowNo: true, default: true}),
   }
 
   private HelpClass!: HelpBaseDerived
@@ -56,7 +56,7 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
 
     let commands = config.commands
     .filter(c => !c.hidden && c.pluginType === 'core')
-    .filter(c => flags.aliases? true : !c.aliases.includes(c.id))
+    .filter(c => flags.aliases ? true : !c.aliases.includes(c.id))
     .map(c => c.id === '.' ? {...c, id: ''} : c)
 
     this.debug('commands:', commands.map(c => c.id).length)

--- a/test/fixtures/cli-command-with-alias/README.md
+++ b/test/fixtures/cli-command-with-alias/README.md
@@ -1,0 +1,17 @@
+# cli-command-with-alias
+
+This file is a test for running `oclif-dev readme` with aliases. If the --no-aliases flag
+is passed as a flag, no aliases should be in the README.
+
+<!-- toc -->
+<!-- tocstop -->
+
+# Usage
+
+<!-- usage -->
+<!-- usagestop -->
+
+# Commands
+
+<!-- commands -->
+<!-- commandsstop -->

--- a/test/fixtures/cli-command-with-alias/package.json
+++ b/test/fixtures/cli-command-with-alias/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "cli-command-with-alias",
+  "files": [
+    "/lib"
+  ],
+  "oclif": {
+    "commands": "./lib/commands",
+    "bin": "oclif",
+    "helpClass": "./lib/help"
+  }
+}

--- a/test/fixtures/cli-command-with-alias/src/commands/hello.ts
+++ b/test/fixtures/cli-command-with-alias/src/commands/hello.ts
@@ -1,0 +1,13 @@
+import {Command} from '@oclif/core'
+
+export default class Hello extends Command {
+  static description = 'a simple command'
+
+  static flags = {}
+
+  static aliases = ['hi']
+
+  async run(): Promise<void> {
+    this.log('hello world')
+  }
+}

--- a/test/fixtures/cli-command-with-alias/src/help.ts
+++ b/test/fixtures/cli-command-with-alias/src/help.ts
@@ -1,0 +1,7 @@
+import {Interfaces, Help} from '@oclif/core'
+
+export default class CustomHelp extends Help {
+  formatCommand(command: Interfaces.Command): string {
+    return `Custom help for ${command.id}`
+  }
+}

--- a/test/fixtures/cli-command-with-alias/src/index.ts
+++ b/test/fixtures/cli-command-with-alias/src/index.ts
@@ -1,0 +1,1 @@
+export {run} from '@oclif/core'

--- a/test/fixtures/cli-command-with-alias/tsconfig.json
+++ b/test/fixtures/cli-command-with-alias/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "importHelpers": true,
+    "module": "commonjs",
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "target": "es2017"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/test/unit/readme.test.ts
+++ b/test/unit/readme.test.ts
@@ -14,6 +14,7 @@ describe('readme', () => {
   .it('runs readme', () => {
     // expect(fs.readFileSync('README.md', 'utf8')).to.contain('manifest')
     expect(fs.readFileSync('README.md', 'utf8')).to.contain('multi')
+    expect(fs.readFileSync('README.md', 'utf8')).to.contain('## `oclif rdm`')
   })
 
   test
@@ -24,6 +25,14 @@ describe('readme', () => {
   .it('runs readme --multi', () => {
     // expect(fs.readFileSync('README.md', 'utf8')).to.contain('manifest')
     expect(fs.readFileSync('README.md', 'utf8')).to.contain('multi')
+  })
+
+  test
+  .stdout()
+  .finally(() => fs.writeFile('README.md', readme))
+  .command(['readme', '--no-aliases'])
+  .it('runs readme --no-aliases', () => {
+    expect(fs.readFileSync('README.md', 'utf8')).not.to.contain('## `oclif rdm`')
   })
 
   describe('with custom help that implements formatCommand', () => {

--- a/test/unit/readme.test.ts
+++ b/test/unit/readme.test.ts
@@ -14,7 +14,6 @@ describe('readme', () => {
   .it('runs readme', () => {
     // expect(fs.readFileSync('README.md', 'utf8')).to.contain('manifest')
     expect(fs.readFileSync('README.md', 'utf8')).to.contain('multi')
-    expect(fs.readFileSync('README.md', 'utf8')).to.contain('## `oclif rdm`')
   })
 
   test
@@ -27,12 +26,31 @@ describe('readme', () => {
     expect(fs.readFileSync('README.md', 'utf8')).to.contain('multi')
   })
 
-  test
-  .stdout()
-  .finally(() => fs.writeFile('README.md', readme))
-  .command(['readme', '--no-aliases'])
-  .it('runs readme --no-aliases', () => {
-    expect(fs.readFileSync('README.md', 'utf8')).not.to.contain('## `oclif rdm`')
+  describe('with command that has an alias', () => {
+    const rootPath = path.join(__dirname, '../fixtures/cli-command-with-alias')
+    const readmePath = path.join(rootPath, 'README.md')
+    const originalReadme = fs.readFileSync(readmePath, 'utf8')
+    const aliasOutput = '`oclif hi`'
+
+    test
+    .stdout()
+    .finally(() => fs.writeFileSync(readmePath, originalReadme))
+    .stub(process, 'cwd', () => rootPath)
+    .command(['readme'])
+    .it('--aliases flag (default)', () => {
+      const newReadme = fs.readFileSync(readmePath, 'utf8')
+      expect(newReadme).to.contain(aliasOutput)
+    })
+
+    test
+    .stdout()
+    .finally(() => fs.writeFileSync(readmePath, originalReadme))
+    .stub(process, 'cwd', () => rootPath)
+    .command(['readme', '--no-aliases'])
+    .it('--no-aliases flag', () => {
+      const newReadme = fs.readFileSync(readmePath, 'utf8')
+      expect(newReadme).not.to.contain(aliasOutput)
+    })
   })
 
   describe('with custom help that implements formatCommand', () => {


### PR DESCRIPTION
This is to allow for `--no-aliases` so the README being generated for a plugin does not include aliases, which may clutter the documentation.

Example usage in `package.json`:
```json
{
  "scripts": {
      "prepack": "oclif manifest && oclif readme --no-aliases"
  }
}
```
