### PR TITLE
fix: await yeoman generators

### DIFF
--- a/src/command-base.ts
+++ b/src/command-base.ts
@@ -2,15 +2,14 @@ import {Command} from '@oclif/core'
 import {createEnv} from 'yeoman-environment'
 
 export default abstract class CommandBase extends Command {
-  protected generate(type: string, generatorOptions: Record<string, unknown> = {}): void {
+  protected async generate(type: string, generatorOptions: Record<string, unknown> = {}): Promise<void> {
     const env = createEnv()
 
     env.register(
       require.resolve(`./generators/${type}`),
       `oclif:${type}`,
     )
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    env.run(`oclif:${type}`, generatorOptions)
+
+    await env.run(`oclif:${type}`, generatorOptions)
   }
 }

--- a/src/command-base.ts
+++ b/src/command-base.ts
@@ -10,6 +10,8 @@ export default abstract class CommandBase extends Command {
       `oclif:${type}`,
     )
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     await env.run(`oclif:${type}`, generatorOptions)
   }
 }

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -13,7 +13,7 @@ This will clone the template repo 'oclif/hello-world' and update package propert
   async run(): Promise<void> {
     const {args} = await this.parse(Generate)
 
-    super.generate('cli', {
+    await super.generate('cli', {
       name: args.name,
       force: true,
     })

--- a/src/commands/generate/command.ts
+++ b/src/commands/generate/command.ts
@@ -15,7 +15,7 @@ export default class GenerateCommand extends CommandBase {
   async run(): Promise<void> {
     const {args, flags} = await this.parse(GenerateCommand)
 
-    super.generate('command', {
+    await super.generate('command', {
       name: args.name,
       force: flags.force,
     })

--- a/src/commands/generate/hook.ts
+++ b/src/commands/generate/hook.ts
@@ -16,7 +16,7 @@ export default class GenerateHook extends CommandBase {
   async run(): Promise<void> {
     const {args, flags} = await this.parse(GenerateHook)
 
-    super.generate('hook', {
+    await super.generate('hook', {
       name: args.name,
       event: flags.event,
       force: flags.force,


### PR DESCRIPTION
Properly await yeoman generators so that the flush timeout doesn't trigger before the user can complete the prompts

Fixes #922 