### PR TITLE
fix: .deb packing privileges

### DIFF
--- a/src/commands/pack/deb.ts
+++ b/src/commands/pack/deb.ts
@@ -75,8 +75,8 @@ export default class PackDeb extends Command {
       await qq.write([workspace, 'DEBIAN/control'], scripts.control(buildConfig, debArch(arch)))
       await qq.chmod([workspace, 'usr/lib', config.dirname, 'bin', config.bin], 0o755)
       await qq.x(`ln -s "../lib/${config.dirname}/bin/${config.bin}" "${workspace}/usr/bin/${config.bin}"`)
-      await qq.x(`chown -R root "${workspace}"`)
-      await qq.x(`chgrp -R root "${workspace}"`)
+      await qq.x(`sudo chown -R root "${workspace}"`)
+      await qq.x(`sudo chgrp -R root "${workspace}"`)
       await qq.x(`dpkg --build "${workspace}" "${qq.join(dist, versionedDebBase)}"`)
     }
 


### PR DESCRIPTION
Currently unable to run the debian packing as a non-root user indepentend of sudo privileges.
Because the `chown` and `chgrp` are used for the `root` group anyway, this is my suggested fix for now.