### PR TITLE
fix: use package name for bin name when generating a CLI with defaults

### DIFF
--- a/src/generators/cli.ts
+++ b/src/generators/cli.ts
@@ -116,6 +116,7 @@ export default class CLI extends Generator {
 
     if (this.options.defaults) {
       this.answers = defaults
+      this.answers.bin = this.answers.name
     } else {
       this.answers = await this.prompt([
         {


### PR DESCRIPTION
When `end()` is called in the CLI generator, the README generator fails with:
```
TypeError: p.replace is not a function
```

This is because the type of `this.answers.bin` is string when set via prompts, but the `oclif/hello-world` repo has since changed its `package.json` to the format:
```json
   "bin":{
      "oex":"./bin/run"
   },
```

This results in `this.pjson.oclif.bin` and `this.pjson.oclif.dirname` being set to the above, which in turn also results in a `package.json` with the following content:
```json
{
   ...
   "bin":{
      "[object Object]":"./bin/run"
   },
   ...
```