### PR TITLE
fix: win pack error

### DIFF
--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -289,6 +289,6 @@ async function signWindows(o: string, arch: string, config: Interfaces.Config, w
     '-in', buildLocationUnsigned,
     '-out', o,
   ]
-  await exec(`osslsigncode sign ${args}.join(' ')`)
+  await exec(`osslsigncode sign ${args.join(' ')}`)
 }
 


### PR DESCRIPTION
fixes an error previously tested on the `beta` prerelease tag that didn't make it into the main PR