### PR TITLE
fix: support yarn 2+ with `pack`

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -65,8 +65,13 @@ export async function build(c: BuildConfig, options: {
   const addDependencies = async () => {
     const yarnRoot = findYarnWorkspaceRoot(c.root) || c.root
     if (fs.existsSync(path.join(yarnRoot, 'yarn.lock'))) {
-      await fs.copy(path.join(yarnRoot, 'yarn.lock'), path.join(c.workspace(), 'yarn.lock'))
-      await exec('yarn --no-progress --production --non-interactive', {cwd: c.workspace()})
+      const yarnVersion = (await exec('yarn -v')).stdout.charAt(0)
+      if (yarnVersion === '1') {
+        await fs.copy(path.join(yarnRoot, 'yarn.lock'), path.join(c.workspace(), 'yarn.lock'))
+        await exec('yarn --no-progress --production --non-interactive', {cwd: c.workspace()})
+      } else {
+        await exec(`yarn workspaces focus ${c.workspace()} --production`, {cwd: yarnRoot})
+      }
     } else {
       const lockpath = fs.existsSync(path.join(c.root, 'package-lock.json')) ?
         path.join(c.root, 'package-lock.json') :


### PR DESCRIPTION
Fixes #759 
Addresses https://github.com/oclif/core/issues/329
Based on and supersedes #989  (`qq` was removed in `3.4.0`)

@mattwebbio I've added `${c.workspace()}` to the command in your PR to specify which workspace in the monorepo to focus on, does this work for you as well?

@mdonnalley @peternhale @mshanemc @RodEsp  respectfully, are external contributions still accepted on oclif repos? The above issues and PRs have withered on the vine without response from maintainers for 6 months in some cases.