### PR TITLE
Add Yarn 2+ support to `pack`

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -66,7 +66,13 @@ export async function build(c: BuildConfig, options: {
     const yarnRoot = findYarnWorkspaceRoot(c.root) || c.root
     if (fs.existsSync(path.join(yarnRoot, 'yarn.lock'))) {
       await fs.copy(path.join(yarnRoot, 'yarn.lock'), path.join(c.workspace(), 'yarn.lock'))
-      await exec('yarn --no-progress --production --non-interactive', {cwd: c.workspace()})
+
+      const yarnVersion = (await exec('yarn -v')).stdout.charAt(0)
+      if (yarnVersion === '1') {
+        await exec('yarn --no-progress --production --non-interactive', {cwd: c.workspace()})
+      } else {
+        await exec('yarn workspaces focus --production', {cwd: c.workspace()})
+      }
     } else {
       const lockpath = fs.existsSync(path.join(c.root, 'package-lock.json')) ?
         path.join(c.root, 'package-lock.json') :

--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -71,7 +71,15 @@ export async function build(c: BuildConfig, options: {
       if (yarnVersion === '1') {
         await exec('yarn --no-progress --production --non-interactive', {cwd: c.workspace()})
       } else {
-        await exec('yarn workspaces focus --production', {cwd: c.workspace()})
+        try {
+          await exec('yarn workspaces focus --production', {cwd: c.workspace()})
+        } catch (error: unknown) {
+          if (error instanceof Error && error.message.includes('Command not found')) {
+            throw new Error('Missing workspace tools. Run `yarn plugin import workspace-tools`.')
+          }
+
+          throw error
+        }
       }
     } else {
       const lockpath = fs.existsSync(path.join(c.root, 'package-lock.json')) ?


### PR DESCRIPTION
Fixes https://github.com/oclif/oclif/issues/759

Closed https://github.com/oclif/oclif/pull/989 and updated this branch to support the deprecation of `qq` introduced in https://github.com/oclif/oclif/pull/1035.