### PR TITLE
fix: workaround wireit

### DIFF
--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -61,7 +61,7 @@ export default class Manifest extends Command {
         this.cloneRepo(repoUrl, fullPath, maxSatisfying)
 
         this.executeCommand('yarn', {cwd: fullPath})
-        this.executeCommand('yarn build', {cwd: fullPath})
+        this.executeCommand('yarn tsc', {cwd: fullPath})
         const plugin = new Plugin({root: fullPath, type: 'jit', ignoreManifest: true, errorOnManifestCreate: true})
         await plugin.load()
 


### PR DESCRIPTION
wireit does not play nicely with child_process and shelljs. We can work around this by using `yarn tsc` instead of `yarn build` for compiling the JIT plugins during manifest generation.