### PR TITLE
Mdonnalley/bugs

### DIFF
--- a/src/generators/cli.ts
+++ b/src/generators/cli.ts
@@ -172,12 +172,12 @@ export default class CLI extends Generator {
           name: 'pkg',
           message: 'Select a package manager',
           choices: [
-            {name: 'yarn', value: 'yarn'},
             {name: 'npm', value: 'npm'},
+            {name: 'yarn', value: 'yarn'},
           ],
           default: () => this.options.yarn || hasYarn ? 1 : 0,
         },
-      ]) as any
+      ])
     }
 
     debug(this.answers)
@@ -226,6 +226,7 @@ export default class CLI extends Generator {
     this.fs.writeJSON(this.destinationPath('./package.json'), this.pjson)
 
     this.fs.write(this.destinationPath('.gitignore'), this._gitignore())
+    this.fs.delete(this.destinationPath('LICENSE'))
   }
 
   end(): void {

--- a/src/generators/cli.ts
+++ b/src/generators/cli.ts
@@ -165,15 +165,15 @@ export default class CLI extends Generator {
           type: 'input',
           name: 'github.repo',
           message: 'What is the GitHub name of repository (https://github.com/owner/REPO)',
-          default: (answers: any) => (this.pjson.repository || answers.name || this.pjson.name).split('/').pop(),
+          default: (answers: any) => (answers.name || this.pjson.repository || this.pjson.name).split('/').pop(),
         },
         {
           type: 'list',
           name: 'pkg',
           message: 'Select a package manager',
           choices: [
-            {name: 'npm', value: 'npm'},
             {name: 'yarn', value: 'yarn'},
+            {name: 'npm', value: 'npm'},
           ],
           default: () => this.options.yarn || hasYarn ? 1 : 0,
         },
@@ -209,6 +209,11 @@ export default class CLI extends Generator {
     this.pjson.oclif.dirname = this.answers.bin
     this.pjson.bin = {}
     this.pjson.bin[this.pjson.oclif.bin] = './bin/run'
+
+    if (!this.options.yarn) {
+      const scripts = (this.pjson.scripts || {}) as Record<string, string>
+      this.pjson.scripts = Object.fromEntries(Object.entries(scripts).map(([k, v]) => [k, v.replace('yarn', 'npm run')]))
+    }
   }
 
   writing(): void {


### PR DESCRIPTION
- Replace instances of `yarn` in package.json scripts if the user selects `npm` for package manager
- Remove salesforce specific LICENSE after cloning template REPO (people can add their own if they'd like)

Fixes #1089 
Fixes #1113 

@W-12588230@
@W-12515006@