### PR TITLE
feat: Add support for Linux arm64

### DIFF
--- a/src/tarballs/config.ts
+++ b/src/tarballs/config.ts
@@ -13,6 +13,7 @@ const exec = promisify(execSync)
 export const TARGETS = [
   'linux-x64',
   'linux-arm',
+  'linux-arm64',
   'win32-x64',
   'win32-x86',
   'darwin-x64',

--- a/src/upload-util.ts
+++ b/src/upload-util.ts
@@ -45,6 +45,7 @@ export function debArch(arch: Interfaces.ArchTypes): string {
   if (arch === 'x64') return 'amd64'
   if (arch === 'x86') return 'i386'
   if (arch === 'arm') return 'armel'
+  if (arch === 'arm64') return 'arm64'
   throw new Error(`invalid arch: ${arch}`)
 }
 

--- a/src/upload-util.ts
+++ b/src/upload-util.ts
@@ -41,7 +41,7 @@ export function templateShortKey(
   return _.template(templates[type])({...options})
 }
 
-export function debArch(arch: Interfaces.ArchTypes): string {
+export function debArch(arch: Interfaces.ArchTypes): 'amd64' | 'i386' | 'armel' | 'arm64' {
   if (arch === 'x64') return 'amd64'
   if (arch === 'x86') return 'i386'
   if (arch === 'arm') return 'armel'


### PR DESCRIPTION
This change adds support for arm64 Linux. Although, in theory, the current `arm` (`armel`) architecture should work thanks to [Multiarch](https://wiki.debian.org/Multiarch) (I'm not familiar, so I may not understood that part), it fails in some situations.

For example, `armel` `deb` installers fail on `ubuntu:focal` Docker images that when executed on a Macbook M1 with the following error:
```
dpkg -i cli.deb
dpkg: error processing archive cli.deb (--install):
 package architecture (armel) does not match system (arm64)
Errors were encountered while processing:
 cli.deb
```

The PR also adds support to upload and promote more architectures for Linux (currently was only `amd64` and `i386`)