### PR TITLE
Qa/1148

### DIFF
--- a/src/commands/upload/deb.ts
+++ b/src/commands/upload/deb.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import aws from '../../aws'
 import {log} from '../../log'
 import * as Tarballs from '../../tarballs'
-import {commitAWSDir, templateShortKey, debVersion, debArch} from '../../upload-util'
+import {commitAWSDir, templateShortKey, debVersion, debArch, DebArch} from '../../upload-util'
 
 export default class UploadDeb extends Command {
   static description = 'upload deb package built with pack:deb'
@@ -42,7 +42,7 @@ export default class UploadDeb extends Command {
       return aws.s3.uploadFile(dist(file), {...S3Options, CacheControl: 'max-age=86400', Key: cloudKey})
     }
 
-    const uploadDeb = async (arch: 'amd64' | 'i386' | 'armel' | 'arm64') => {
+    const uploadDeb = async (arch: DebArch) => {
       const deb = templateShortKey('deb', {bin: config.bin, versionShaRevision: debVersion(buildConfig), arch: arch as any})
       if (fs.existsSync(dist(deb))) await Promise.all([upload(deb), uploadWorkaround(deb)])
     }

--- a/src/tarballs/config.ts
+++ b/src/tarballs/config.ts
@@ -13,6 +13,7 @@ const exec = promisify(execSync)
 export const TARGETS = [
   'linux-x64',
   'linux-arm',
+  'linux-arm64',
   'win32-x64',
   'win32-x86',
   'darwin-x64',

--- a/src/upload-util.ts
+++ b/src/upload-util.ts
@@ -41,7 +41,9 @@ export function templateShortKey(
   return _.template(templates[type])({...options})
 }
 
-export function debArch(arch: Interfaces.ArchTypes): 'amd64' | 'i386' | 'armel' | 'arm64' {
+export type DebArch = 'amd64' | 'i386' | 'armel' | 'arm64'
+
+export function debArch(arch: Interfaces.ArchTypes): DebArch {
   if (arch === 'x64') return 'amd64'
   if (arch === 'x86') return 'i386'
   if (arch === 'arm') return 'armel'

--- a/src/upload-util.ts
+++ b/src/upload-util.ts
@@ -45,6 +45,7 @@ export function debArch(arch: Interfaces.ArchTypes): string {
   if (arch === 'x64') return 'amd64'
   if (arch === 'x86') return 'i386'
   if (arch === 'arm') return 'armel'
+  if (arch === 'arm64') return 'arm64'
   throw new Error(`invalid arch: ${arch}`)
 }
 

--- a/src/upload-util.ts
+++ b/src/upload-util.ts
@@ -41,7 +41,7 @@ export function templateShortKey(
   return _.template(templates[type])({...options})
 }
 
-export function debArch(arch: Interfaces.ArchTypes): string {
+export function debArch(arch: Interfaces.ArchTypes): 'amd64' | 'i386' | 'armel' | 'arm64' {
   if (arch === 'x64') return 'amd64'
   if (arch === 'x86') return 'i386'
   if (arch === 'arm') return 'armel'


### PR DESCRIPTION
This change adds support for arm64 Linux. Although, in theory, the current arm (armel) architecture should work thanks to [Multiarch](https://wiki.debian.org/Multiarch) (I'm not familiar, so I may not understood that part), it fails in some situations.

For example, armel deb installers fail on ubuntu:focal Docker images that when executed on a Macbook M1 with the following error:

dpkg -i cli.deb
dpkg: error processing archive cli.deb (--install):
 package architecture (armel) does not match system (arm64)
Errors were encountered while processing:
 cli.deb
The PR also adds support to upload and promote more architectures for Linux (currently was only amd64 and i386)

originally https://github.com/oclif/oclif/pull/1148