### PR TITLE
Changing hello example(deprecated) to hello world example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ COMMANDS
   hello
   help   display help for mynewcli
 
-$ ./bin/run hello
-hello world from ./src/hello.js!
+$ ./bin/run hello world
+hello world! (./src/commands/hello/world.ts)
 ```
 
 # 📚 Examples


### PR DESCRIPTION
The hello command does not work by itself. I believe It now requires an accompanying argument, either specifying a person's name or using "world".

