### PR TITLE
fix: respect topic sep when generating readme

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -221,7 +221,7 @@ USAGE
   private commandPath(plugin: Interfaces.Plugin, c: Command.Cached): string | undefined {
     const commandsDir = plugin.pjson.oclif.commands
     if (!commandsDir) return
-    let p = path.join(plugin.root, commandsDir, ...c.id.split(':'))
+    let p = path.join(plugin.root, commandsDir, ...c.id.split(plugin.pjson.oclif.topicSeparator ?? ':'))
     const libRegex = new RegExp('^lib' + (path.sep === '\\' ? '\\\\' : path.sep))
     if (fs.pathExistsSync(path.join(p, 'index.js'))) {
       p = path.join(p, 'index.js')

--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -173,11 +173,14 @@ USAGE
     }
 
     try {
+      // copy c to keep the command ID with colons, see:
+      // https://github.com/oclif/oclif/pull/1165#discussion_r1282305242
+      const command = {...c}
       return compact([
         header(),
         title,
         '```\n' + wrapper.formatCommand(c).trim() + '\n```',
-        this.commandCode(config, c),
+        this.commandCode(config, command),
       ]).join('\n\n')
     } catch (error: any) {
       this.error(error.message)
@@ -221,7 +224,7 @@ USAGE
   private commandPath(plugin: Interfaces.Plugin, c: Command.Cached): string | undefined {
     const commandsDir = plugin.pjson.oclif.commands
     if (!commandsDir) return
-    let p = path.join(plugin.root, commandsDir, ...c.id.split(plugin.pjson.oclif.topicSeparator ?? ':'))
+    let p = path.join(plugin.root, commandsDir, ...c.id.split(':'))
     const libRegex = new RegExp('^lib' + (path.sep === '\\' ? '\\\\' : path.sep))
     if (fs.pathExistsSync(path.join(p, 'index.js'))) {
       p = path.join(p, 'index.js')

--- a/yarn.lock
+++ b/yarn.lock
@@ -640,10 +640,10 @@
     is-wsl "^2.1.1"
     tslib "^2.5.0"
 
-"@oclif/core@^2.9.3", "@oclif/core@^2.9.4":
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.9.4.tgz#5b22415e238fc3e0db08b0350b85b417ead6e6ff"
-  integrity sha512-eFRRpV+tJ6nMkhay2M9IppjSF3atRrgj6Qo83qUslaFSAW3NAl4mIhx1mKmTwQx5rgSrar03xICtSAWJ6gZtag==
+"@oclif/core@^2.11.4", "@oclif/core@^2.9.3":
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.11.5.tgz#3e278957d605399a0fe7700b26dcab64f6ee4608"
+  integrity sha512-ALv0YyaMwfy+LRGigKoqST/It8uYBwp1+3F4OpwmPpQl7BiRCGbOBnJSrWNNCAEMZiYpWNgF/3WQVB5VUQlYbQ==
   dependencies:
     "@types/cli-progress" "^3.11.0"
     ansi-escapes "^4.3.2"


### PR DESCRIPTION
Closes https://github.com/oclif/oclif/issues/1128

`oclif readme` would miss the `See code` block in CLIs using spaces as a topic separator.

Test:
1) clone https://github.com/cristiand391/sf-plugin-api
2) run `yarn oclif readme`, no `See code` in readme
3) yarn link this PR into the plugin, repeat step 2.

@W-13872809@