### PR TITLE
fix: hide module type prompt behind OCLIF_ALLOW_ESM env var

### DIFF
--- a/src/generators/cli.ts
+++ b/src/generators/cli.ts
@@ -61,12 +61,13 @@ export default class CLI extends Generator {
     }
   }
 
+  // eslint-disable-next-line complexity
   async prompting(): Promise<void> {
     const msg = 'Time to build an oclif CLI!'
 
     this.log(`${msg} Version: ${version}`)
 
-    const {moduleType} = await this.prompt([
+    const {moduleType} = process.env.OCLIF_ALLOW_ESM ? await this.prompt([
       {
         type: 'list',
         name: 'moduleType',
@@ -77,7 +78,7 @@ export default class CLI extends Generator {
         ],
         default: 'cjs',
       },
-    ])
+    ]) : 'cjs'
 
     const repo = moduleType === 'esm' ? 'hello-world-esm' : 'hello-world'
     execSync(`git clone https://github.com/oclif/${repo}.git "${path.resolve(this.name)}" --depth=1`)


### PR DESCRIPTION
Hide module type prompt behind `OCLIF_ALLOW_ESM` env var until we are closer to more complete ESM support