### PR TITLE
Add a timestamp authority to win:pack

### DIFF
--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -291,6 +291,7 @@ async function signWindows(o: string, arch: string, config: Interfaces.Config, w
     '-pass', pass,
     '-n', `"${windows.name}"`,
     '-i', windows.homepage || config.pjson.homepage,
+    '-t', 'http://timestamp.digicert.com',
     '-h', 'sha512',
     '-in', buildLocationUnsigned,
     '-out', o,


### PR DESCRIPTION
When a windows signing cert expires, all past `exe` files signed with that certificate also show as expired. Even if they were signed during a time that the cert was still valid. It looks like we can pass a timestamp (from a timestamp authority) that will allow old files signed before expiration to still show as valid. 

This can useful when an windows cert expires, users could be instructed to install an old `exe` and then run `<bin> update` to get the latest version. 

[@W-13992209@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13992209)

[Information on timestamp validation](https://codesigningstore.com/code-signing-architecture-how-it-works#:~:text=Time%20Stamp%20Authority%20(TSA),-Code%20Signing%20process&text=Although%20this%20part%20is%20optional,signature%20is%20sent%20to%20it.)
[Digicert Timestamp Authority](https://knowledge.digicert.com/solution/SO912.html)