### PR TITLE
feat: improve perf of manifest command

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "posttest": "yarn run lint",
     "prepack": "shx rm -rf lib && tsc && bin/dev manifest .",
     "test": "nps test && yarn test:unit && yarn test:integration",
-    "test:integration": "mocha --forbid-only \"test/integration/*.test.ts\"",
+    "test:integration": "mocha --forbid-only \"test/integration/*.test.ts\" --timeout 600000",
     "test:unit": "mocha --forbid-only \"test/unit/*.test.ts\"",
     "version": "bin/dev readme && git add README.md"
   },

--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -116,6 +116,12 @@ export default class Manifest extends Command {
 
   private getVersion(plugin: string, version: string): string {
     if (version.startsWith('^') || version.startsWith('~')) {
+      // Grab latest from npm to get all the versions so we can find the max satisfying version.
+      // We explicitly ask for latest since this command is typically run inside of `npm prepack`,
+      // which sets the npm_config_tag env var, which is used as the default anytime a tag isn't
+      // provided to `npm view`. This can be problematic if you're building the `nightly` version
+      // of a CLI and all the JIT plugins don't have a `nightly` tag themselves.
+      // TL;DR - always ask for latest to avoid potentially requesting a non-existent tag.
       const {versions} = JSON.parse(this.executeCommand(`npm view ${plugin}@latest --json`).stdout) as {
         versions: string[]
       }

--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -4,6 +4,12 @@ import * as path from 'path'
 import * as os from 'os'
 import * as semver from 'semver'
 import {exec, ShellString, ExecOptions} from 'shelljs'
+import got from 'got'
+import {promisify} from 'util'
+import {pipeline as pipelineSync} from 'stream'
+import {checkFor7Zip} from '../util'
+
+const pipeline = promisify(pipelineSync)
 
 async function fileExists(filePath: string): Promise<boolean> {
   try {
@@ -47,25 +53,33 @@ export default class Manifest extends Command {
       const tmpDir = os.tmpdir()
       const promises = Object.entries(packageJson.oclif.jitPlugins).map(async ([jitPlugin, version]) => {
         const pluginDir = jitPlugin.replace('/', '-').replace('@', '')
-        const repo = this.executeCommand(`npm view ${jitPlugin}@latest repository --json`)
-        const stdout = JSON.parse(repo.stdout)
-
-        const repoUrl = stdout.url.replace(`${stdout.type}+`, '')
 
         const fullPath = path.join(tmpDir, pluginDir)
+
         if (await fileExists(fullPath)) await fs.remove(fullPath)
 
-        const versions = JSON.parse(this.executeCommand(`npm view ${jitPlugin}@latest versions --json`).stdout)
-        const maxSatisfying = semver.maxSatisfying(versions, version)
+        await fs.mkdir(fullPath, {recursive: true})
 
-        this.cloneRepo(repoUrl, fullPath, maxSatisfying)
+        const tarballUrl = this.getTarballUrl(jitPlugin, version)
+        const tarball = path.join(fullPath, path.basename(tarballUrl))
+        await pipeline(
+          got.stream(tarballUrl),
+          fs.createWriteStream(tarball),
+        )
 
-        this.executeCommand('yarn --ignore-scripts', {cwd: fullPath})
-        this.executeCommand('yarn tsc', {cwd: fullPath})
-        const plugin = new Plugin({root: fullPath, type: 'jit', ignoreManifest: true, errorOnManifestCreate: true})
-        await plugin.load()
+        if (process.platform === 'win32') {
+          await checkFor7Zip()
+          exec(`7z x -bd -y "${tarball}"`, {cwd: fullPath})
+        } else {
+          exec(`tar -xJf "${tarball}"`, {cwd: fullPath})
+        }
 
-        return plugin.manifest
+        const manifest = await fs.readJSON(path.join(fullPath, 'package', 'oclif.manifest.json')) as Interfaces.Manifest
+        for (const command of Object.values(manifest.commands)) {
+          command.pluginType = 'jit'
+        }
+
+        return manifest
       })
 
       ux.action.start('Generating JIT plugin manifests')
@@ -99,16 +113,30 @@ export default class Manifest extends Command {
     this.log(`wrote manifest to ${file}`)
   }
 
-  private cloneRepo(repoUrl: string, fullPath: string, tag: string | semver.SemVer | null): void {
-    try {
-      this.executeCommand(`git clone --branch ${tag} ${repoUrl} ${fullPath} --depth 1`)
-    } catch {
-      try {
-        this.executeCommand(`git clone --branch v${tag} ${repoUrl} ${fullPath} --depth 1`)
-      } catch {
-        throw new Error(`Unable to clone repo ${repoUrl} with tag ${tag}`)
+  private getTarballUrl(plugin: string, version: string): string {
+    // jit plugin is unpinned so we need to figure out the max satisfying version
+    if ((version.startsWith('^') || version.startsWith('~'))) {
+      const npmLatest = JSON.parse(this.executeCommand(`npm view ${plugin}@latest --json`).stdout) as {
+        versions: string[]
+        dist: { tarball: string }
       }
+      const maxSatisfying = semver.maxSatisfying(npmLatest.versions, version)
+
+      const {dist} = JSON.parse(this.executeCommand(`npm view ${plugin}@${maxSatisfying} --json`).stdout) as {
+        versions: string[]
+        dist: { tarball: string }
+      }
+
+      return dist.tarball
     }
+
+    // jit plugin is pinned so we don't need to figure out the max satisfying version
+    const {dist} = JSON.parse(this.executeCommand(`npm view ${plugin}@${version} --json`).stdout) as {
+      versions: string[]
+      dist: { tarball: string }
+    }
+    return dist.tarball
+
   }
 
   private executeCommand(command: string, options?: ExecOptions): ShellString {

--- a/src/tarballs/node.ts
+++ b/src/tarballs/node.ts
@@ -1,12 +1,13 @@
-import {Errors, Interfaces} from '@oclif/core'
+import {Interfaces} from '@oclif/core'
 import * as path from 'path'
 import * as fs from 'fs-extra'
-import {pipeline as pipelineSync} from 'node:stream'
+import {pipeline as pipelineSync} from 'stream'
 import {log} from '../log'
-import {exec as execSync} from 'node:child_process'
-import {promisify} from 'node:util'
+import {exec as execSync} from 'child_process'
+import {promisify} from 'util'
 import got from 'got'
 import * as retry from 'async-retry'
+import {checkFor7Zip} from '../util'
 
 const pipeline = promisify(pipelineSync)
 
@@ -20,15 +21,6 @@ type Options = {
   platform: Interfaces.PlatformTypes;
   arch: Interfaces.ArchTypes | 'armv7l';
   tmp: string
-}
-
-async function checkFor7Zip() {
-  try {
-    await exec('7z')
-  } catch (error: any) {
-    if (error.code === 127)  Errors.error('install 7-zip to package windows tarball')
-    else throw error
-  }
 }
 
 export async function fetchNodeBinary({nodeVersion, output, platform, arch, tmp}: Options): Promise<string> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,12 @@
+import {Errors} from '@oclif/core'
 import _ = require('lodash')
 import * as os from 'os'
-import * as crypto from 'node:crypto'
+import * as crypto from 'crypto'
 import {log} from './log'
 import * as fs from 'fs-extra'
+import {exec as execSync} from 'child_process'
+import {promisify} from 'util'
+const exec = promisify(execSync)
 
 export function castArray<T>(input?: T | T[]): T[] {
   if (input === undefined) return []
@@ -90,4 +94,13 @@ export const hash = async (algo: string, fp: string | string[]):Promise<string> 
     stream.on('data', chunk => hashInProgress.update(chunk))
     stream.on('end', () => resolve(hashInProgress.digest('hex')))
   })
+}
+
+export async function checkFor7Zip() {
+  try {
+    await exec('7z')
+  } catch (error: any) {
+    if (error.code === 127)  Errors.error('install 7-zip to package windows tarball')
+    else throw error
+  }
 }

--- a/test/integration/sf.test.ts
+++ b/test/integration/sf.test.ts
@@ -1,0 +1,54 @@
+import {Interfaces} from '@oclif/core'
+import {expect} from 'chai'
+import {execSync} from 'node:child_process'
+import { read } from 'node:fs'
+import {access, mkdir, readFile, rm} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+const exists = async (filePath: string): Promise<boolean> => {
+  try {
+    await access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('sf', () => {
+
+  describe('manifest', () => {
+    const testDir = join(tmpdir(), 'sf-manifest-integration-test')
+    const sfDir = join(testDir, 'cli')
+
+    before(async () => {
+      if (await exists(testDir)) {
+        await rm(testDir, {recursive: true, force: true})
+      }
+
+      await mkdir(testDir, {recursive: true})
+      execSync(`git clone https://github.com/salesforcecli/cli.git`, {cwd: testDir})
+      execSync('yarn --ignore-scripts', {cwd: sfDir})
+      execSync('yarn build', {cwd: sfDir})
+    })
+
+    it('should generate manifest with JIT plugins', async () => {
+      const binDev = process.platform === 'win32' ? join(process.cwd(), 'bin', 'dev.cmd') : join(process.cwd(), 'bin', 'dev')
+
+      execSync(`${binDev} manifest`, {cwd: sfDir})
+
+      const manifest = JSON.parse(await readFile(join(sfDir, 'oclif.manifest.json'), 'utf8')) as Interfaces.Manifest
+
+      const sfPjson = JSON.parse(await readFile(join(sfDir, 'package.json'), 'utf8')) as Interfaces.PJSON.Plugin
+      const jitPlugins = Object.keys(sfPjson.oclif.jitPlugins ?? {})
+
+      const everyPluginHasCommand = jitPlugins.every(jitPlugin => !!Object.values(manifest.commands).find(command => command.pluginName === jitPlugin))
+      const everyJITCommandIsTypeJIT = Object.values(manifest.commands)
+        .filter(command => jitPlugins.includes(command.pluginName ?? ''))
+        .every(command => command.pluginType === 'jit')
+
+      expect(everyPluginHasCommand).to.be.true
+      expect(everyJITCommandIsTypeJIT).to.be.true
+    })
+  })
+})


### PR DESCRIPTION
For jit plugins `manifest` now downloads and extracts the npm package to get the `oclif.manifest.json` for the specified version. This is significantly faster than cloning and building each JIT plugin's repository

@W-14122700@