### PR TITLE
fix: extract gz not xz

### DIFF
--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -72,7 +72,7 @@ export default class Manifest extends Command {
           await checkFor7Zip()
           exec(`7z x -bd -y "${tarball}"`, {cwd: fullPath})
         } else {
-          exec(`tar -xJf "${tarball}"`, {cwd: fullPath})
+          exec(`tar -xzf "${tarball}"`, {cwd: fullPath})
         }
 
         const manifest = await fs.readJSON(path.join(fullPath, 'package', 'oclif.manifest.json')) as Interfaces.Manifest


### PR DESCRIPTION
I _think_ this will fix this error:
`xz: (stdin): File format not recognized` ([action run](https://github.com/salesforcecli/cli/actions/runs/6263970294/job/17009588881?pr=1162#step:6:11))

The tarball we are downloading from `npm` uses `gz` compression, not `xz`. This PR switches from using the `-J` flag to `-z`. This still works locally on a Mac (I added a temp log to confirm it was linked correctly):
<img width="759" alt="Screenshot 2023-09-21 at 11 42 50 AM" src="https://github.com/oclif/oclif/assets/1715111/67d3d1c2-7348-4ced-896f-28ae0e1958d2">

I also did a diff on manifests generated before and after this change and they were the same.
[@W-14122700@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14122700)