### PR TITLE
fix: missing core yarn files

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -69,7 +69,7 @@ export async function build(
 
   const isYarnProject = (yarnRootPath: string) => {
     const yarnLockFileName = 'yarn.lock'
-    const rootYarnLockFilePath = path.join(yarnRoot, yarnLockFileName)
+    const rootYarnLockFilePath = path.join(yarnRootPath, yarnLockFileName)
 
     return existsSync(rootYarnConfigFilePath)
   }


### PR DESCRIPTION
Newer versions of yarn depend on more files than "yarn.lock". As a result, the tarballs need to include these core files to ensure that any future commands against the tarball contents utilize the right version of `yarn`.

## Example

Configuring yarn v4 with a "pinned version" requires the ".yarnrc.yml" file along with the `yarnPath` configuration value. If configured to use a specific version of yarn, Yarn will download required files into a "./.yarn/releases/" directory. In the future, any execution of `yarn` will pick up the `yarnPath` configuration and use the "./.yarn/releases/" directory contents to download and use the specific version of yarn.

## Current impacts

Without these changes, modern versions of `yarn`, like Yarn v4, do not properly install their dependencies when packaging for release. For example, if yarn 4 is configured to scope dependency installations to the workspace and use a classic node modules setup, the current build will only copy "yarn.lock" and either not upgrade Yarn to v4 and not copy (respect) the v4 configuration from ".yarnrc.yml" or will properly discover and use yarn v4 via `corepack` from the "package.json" file and "packageManager" value, but will still not copy (respect) the v4 configuration from ".yarnrc.yml".

## Testing these changes

1. An existing oclif CLI was "monkey-patched" with these changes by editing the generated oclif file "my-cli\node_modules\oclif\lib\tarballs\build.js" with a slightly modified version of these same changes.
2. `yarn build`
3. `yarn oclif pack win`