### PR TITLE
fix: readme command does not parse path correctly on windows

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -259,7 +259,7 @@ USAGE
     if (!commandsDir) return
     const hasTypescript = plugin.pjson.devDependencies?.typescript || plugin.pjson.dependencies?.typescript
     let p = path.join(plugin.root, commandsDir, ...c.id.split(':'))
-    const outDir = path.dirname(commandsDir.replace(`.${path.sep}`, ''))
+    const outDir = path.dirname(commandsDir.replace('/^./|.\\/', ''))
     const outDirRegex = new RegExp('^' + outDir + (path.sep === '\\' ? '\\\\' : path.sep))
     if (fs.pathExistsSync(path.join(p, 'index.js'))) {
       p = path.join(p, 'index.js')


### PR DESCRIPTION
This fixes issue #1232. I replaced the string pattern in the call to `commandDir.replace` with a RegEx that will accept either `./` or `.\`. As per the [node docs](https://nodejs.org/api/path.html#pathsep), the only two possible values for `path.sep` are / for POSIX and \ for Windows. Thus, I don't see any issue replacing the path.sep with the RegEx to check for the / or \ characters.