### PR TITLE
fix: outdir regex in readme

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -259,7 +259,7 @@ USAGE
     if (!commandsDir) return
     const hasTypescript = plugin.pjson.devDependencies?.typescript || plugin.pjson.dependencies?.typescript
     let p = path.join(plugin.root, commandsDir, ...c.id.split(':'))
-    const outDir = path.dirname(commandsDir.replace('/^./|.\\/', ''))
+    const outDir = path.dirname(commandsDir.replace(/^.\/|.\\/, '')) // remove leading ./ or .\ from path
     const outDirRegex = new RegExp('^' + outDir + (path.sep === '\\' ? '\\\\' : path.sep))
     if (fs.pathExistsSync(path.join(p, 'index.js'))) {
       p = path.join(p, 'index.js')

--- a/test/integration/cli.test.ts
+++ b/test/integration/cli.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai'
 import {ExecOptions, exec as cpExec} from 'node:child_process'
 import {existsSync} from 'node:fs'
-import {mkdir, rm} from 'node:fs/promises'
+import {mkdir, readFile, rm} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
@@ -66,5 +66,20 @@ describe('Generated CLI Integration Tests', () => {
     const result = await exec(`${cliBinDev} foo:bar:baz`, {cwd: cliDir})
     expect(result.code).to.equal(0)
     expect(result.stdout).to.include('example hook running foo:bar:baz\n')
+  })
+
+  it('should generate a README', async () => {
+    const genResult = await exec(`${executable} readme`, {cwd: cliDir})
+    expect(genResult.code).to.equal(0)
+    const contents = await readFile(join(cliDir, 'README.md'), 'utf8')
+
+    // Ensure that the README doesn't contain any references to the dist/ folder
+    const distRegex = /dist\//g
+    const distMatches = contents.match(distRegex)
+    expect(distMatches).to.be.null
+
+    const srcRegex = /src\//g
+    const srcMatches = contents.match(srcRegex)
+    expect(srcMatches).to.not.be.null
   })
 })


### PR DESCRIPTION
Fixes the regex used for finding the `outDir` during readme generation