### PR TITLE
feat: add node.options

### DIFF
--- a/src/tarballs/bin.ts
+++ b/src/tarballs/bin.ts
@@ -10,10 +10,12 @@ const exec = promisify(execSync)
 export async function writeBinScripts({
   baseWorkspace,
   config,
+  nodeOptions,
   nodeVersion,
 }: {
   baseWorkspace: string
   config: Interfaces.Config
+  nodeOptions: string[]
   nodeVersion: string
 }): Promise<void> {
   const binPathEnvVar = config.scopedEnvVarKey('BINPATH')
@@ -32,12 +34,13 @@ if not "%${redirectedEnvVar}%"=="1" if exist "%LOCALAPPDATA%\\${bin}\\client\\bi
 )
 
 if not defined ${binPathEnvVar} set ${binPathEnvVar}="%~dp0${bin}.cmd"
+
 if exist "%~dp0..\\bin\\node.exe" (
-  "%~dp0..\\bin\\node.exe" "%~dp0..\\bin\\run" %*
+  "%~dp0..\\bin\\node.exe" ${`${nodeOptions.join(' ')} `}"%~dp0..\\bin\\run" %*
 ) else if exist "%LOCALAPPDATA%\\oclif\\node\\node-${nodeVersion}.exe" (
-  "%LOCALAPPDATA%\\oclif\\node\\node-${nodeVersion}.exe" "%~dp0..\\bin\\run" %*
+  "%LOCALAPPDATA%\\oclif\\node\\node-${nodeVersion}.exe" ${`${nodeOptions.join(' ')} `}"%~dp0..\\bin\\run" %*
 ) else (
-  node "%~dp0..\\bin\\run" %*
+  node ${`${nodeOptions.join(' ')} `}"%~dp0..\\bin\\run" %*
 )
 `,
     )
@@ -88,9 +91,9 @@ else
     exit 1
   fi
   if [ "\$DEBUG" == "*" ]; then
-    echoerr ${binPathEnvVar}="\$${binPathEnvVar}" "\$NODE" "\$DIR/run" "\$@"
+    echoerr ${binPathEnvVar}="\$${binPathEnvVar}" "\$NODE" ${`${nodeOptions.join(' ')} `}"\$DIR/run" "\$@"
   fi
-  "\$NODE" "\$DIR/run" "\$@"
+  "\$NODE" ${`${nodeOptions.join(' ')} `}"\$DIR/run" "\$@"
 fi
 `,
       {mode: 0o755},

--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -232,7 +232,7 @@ export async function build(
   await extractCLI(options.tarball ?? (await packCLI()))
   await updatePJSON()
   await addDependencies()
-  await writeBinScripts({baseWorkspace: c.workspace(), config, nodeVersion: c.nodeVersion})
+  await writeBinScripts({baseWorkspace: c.workspace(), config, nodeOptions: c.nodeOptions, nodeVersion: c.nodeVersion})
   await pretarball()
   const targetsToBuild = c.targets.filter((t) => !options.platform || options.platform === t.platform)
   if (options.parallel) {


### PR DESCRIPTION
Allow specifying [options to the Node process](https://nodejs.org/api/cli.html#options) when creating the CLI binary in the `pack:tarballs` command.

Example of useful options include:
- [`--max-old-space-size=...`](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes) to increase memory size
- [`--disable-warning=...`](https://nodejs.org/api/cli.html#--disable-warningcode-or-type) to disable warnings, e.g, `ExperimentalWarning`

The list of options can be specified as a string array or space-separated string in the `oclif.update.node.options` section of the `package.json`:

example:

```json
{
  "oclif": {
    "update": {
      "node": {
        "options": ["--max-old-space-size=4096", "--no-warnings"]
      }
    }
  }
}
```

or:

```json
{
  "oclif": {
    "update": {
      "node": {
        "options": "--max-old-space-size=4096 --no-warnings"
      }
    }
  }
}
```

