### PR TITLE
feat: deprecate and hide lock command

### DIFF
--- a/src/commands/lock.ts
+++ b/src/commands/lock.ts
@@ -24,6 +24,9 @@ export default class Lock extends Command {
     this.hidden = true
     this.state = 'deprecated'
     this.summary = 'Copy the yarn.lock to oclif.lock'
+    this.deprecationOptions = {
+      message: 'oclif.lock is deprecated and will be removed in @oclif/plugin-plugins v5.0.0 and above.',
+    }
     this.description = `Using oclif.lock allows your plugins dependencies to be locked to the version specified in the lock file during plugin install.
 Once the oclif.lock file is created you can include it your npm package by adding it to the files property of your package.json. We do not recommend committing the oclif.lock file to git.
 

--- a/src/commands/lock.ts
+++ b/src/commands/lock.ts
@@ -21,8 +21,12 @@ export default class Lock extends Command {
   }
 
   static {
+    this.hidden = true
+    this.state = 'deprecated'
     this.summary = 'Copy the yarn.lock to oclif.lock'
     this.description = `Using oclif.lock allows your plugins dependencies to be locked to the version specified in the lock file during plugin install.
-Once the oclif.lock file is created you can include it your npm package by adding it to the files property of your package.json. We do not recommend committing the oclif.lock file to git.`
+Once the oclif.lock file is created you can include it your npm package by adding it to the files property of your package.json. We do not recommend committing the oclif.lock file to git.
+
+PLEASE NOTE: the oclif.lock will only work for @oclif/plugin-plugins v3.4.0 and above. It will NOT be supported in v5.0.0 and above.`
   }
 }


### PR DESCRIPTION
Deprecate and hide the `lock` command since the `oclif.lock` feature will not be supported in the next major version of `@oclif/plugin-plugins` (see https://github.com/oclif/plugin-plugins/pull/776)