### PR TITLE
fix: correct S3 key generation for /apt/./ During deb artifacts promotion (#1265)

### DIFF
--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -196,7 +196,7 @@ export default class Promote extends Command {
           // see https://github.com/oclif/oclif/issues/347 for the AWS-redirect that solves this
           // this workaround puts the code in both places that the redirect was doing
           // with this, the docs are correct. The copies are all done in parallel so it shouldn't be too costly.
-          const workaroundKey = cloudChannelKey(`apt/./${artifact}`)
+          const workaroundKey = `${cloudChannelKey('apt/')}./${artifact}`
           return [
             aws.s3.copyObject({
               ...awsDefaults,


### PR DESCRIPTION
fix #1265