### PR TITLE
fix: update logic for exclusion from Windows Defender scans

### DIFF
--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -93,13 +93,15 @@ Section "Set PATH to ${config.name}"
   Call AddToPath
 SectionEnd
 
-Section ${defenderOptionDefault ? '' : '/o '}"${hideDefenderOption ? '-' : ''}Add %LOCALAPPDATA%\\${
+${hideDefenderOption ? '' : `
+Section ${defenderOptionDefault ? '' : '/o '}"Add %LOCALAPPDATA%\\${
     config.dirname
   } to Windows Defender exclusions (highly recommended for performance!)"
   ExecShell "" '"$0"' "/C powershell -ExecutionPolicy Bypass -Command $\\"& {Add-MpPreference -ExclusionPath $\\"$LOCALAPPDATA\\${
     config.dirname
   }$\\"}$\\" -FFFeatureOff" SW_HIDE
 SectionEnd
+`}
 
 Section "Uninstall"
   Delete "$INSTDIR\\Uninstall.exe"

--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -285,8 +285,7 @@ the CLI should already exist in a directory named after the CLI that is the root
               config,
               customization: nsisCustomization,
               // hiding it also unchecks it
-              defenderOptionDefault:
-                flags['defender-exclusion'] === 'hidden' ? false : flags['default-defender-exclusion'],
+              defenderOptionDefault: flags['defender-exclusion'] === 'hidden' || flags['defender-exclusion'] === 'unchecked' ? false : true,
               hideDefenderOption: flags['defender-exclusion'] === 'hidden',
             }),
           ),

--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -93,15 +93,13 @@ Section "Set PATH to ${config.name}"
   Call AddToPath
 SectionEnd
 
-${hideDefenderOption ? '' : `
-Section ${defenderOptionDefault ? '' : '/o '}"Add %LOCALAPPDATA%\\${
+Section ${defenderOptionDefault ? '' : '/o '}"${hideDefenderOption ? '-' : ''}Add %LOCALAPPDATA%\\${
     config.dirname
   } to Windows Defender exclusions (highly recommended for performance!)"
   ExecShell "" '"$0"' "/C powershell -ExecutionPolicy Bypass -Command $\\"& {Add-MpPreference -ExclusionPath $\\"$LOCALAPPDATA\\${
     config.dirname
   }$\\"}$\\" -FFFeatureOff" SW_HIDE
 SectionEnd
-`}
 
 Section "Uninstall"
   Delete "$INSTDIR\\Uninstall.exe"
@@ -289,7 +287,7 @@ the CLI should already exist in a directory named after the CLI that is the root
               // hiding it also unchecks it
               defenderOptionDefault:
                 flags['defender-exclusion'] === 'hidden' ? false : flags['default-defender-exclusion'],
-              hideDefenderOption: flags['hide-defender-option'] === 'hidden',
+              hideDefenderOption: flags['defender-exclusion'] === 'hidden',
             }),
           ),
           ...(config.binAliases

--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -32,13 +32,13 @@ if exist "%LOCALAPPDATA%\\${config.dirname}\\client\\bin\\${additionalCLI ?? con
     arch,
     config,
     customization,
-    defenderOptionDefault,
+    defenderOptional,
     hideDefenderOption,
   }: {
     arch: string
     config: Interfaces.Config
     customization?: string
-    defenderOptionDefault: boolean
+    defenderOptional: boolean
     hideDefenderOption: boolean
   }) => `!include MUI2.nsh
 
@@ -93,7 +93,7 @@ Section "Set PATH to ${config.name}"
   Call AddToPath
 SectionEnd
 
-Section ${defenderOptionDefault ? '' : '/o '}"${hideDefenderOption ? '-' : ''}Add %LOCALAPPDATA%\\${
+Section ${defenderOptional ? '/o ' : ''}"${hideDefenderOption ? '-' : ''}Add %LOCALAPPDATA%\\${
     config.dirname
   } to Windows Defender exclusions (highly recommended for performance!)"
   ExecShell "" '"$0"' "/C powershell -ExecutionPolicy Bypass -Command $\\"& {Add-MpPreference -ExclusionPath $\\"$LOCALAPPDATA\\${
@@ -285,7 +285,7 @@ the CLI should already exist in a directory named after the CLI that is the root
               config,
               customization: nsisCustomization,
               // hiding it also unchecks it
-              defenderOptionDefault: flags['defender-exclusion'] === 'hidden' || flags['defender-exclusion'] === 'unchecked' ? false : true,
+              defenderOptional: flags['defender-exclusion'] === 'hidden' || flags['defender-exclusion'] === 'unchecked',
               hideDefenderOption: flags['defender-exclusion'] === 'hidden',
             }),
           ),


### PR DESCRIPTION
Unfortunately after the changes in #1210 we are still seeing the option to exclude the LOCALAPPDATA directory from Windows Defender scans when installing the Heroku CLI on Windows when the installer has been built with the `--defender-exclusion hidden` option (though it is no longer selected by default).

![image](https://github.com/oclif/oclif/assets/12739849/8ab3b987-53b1-49b4-a846-c79f8c077ff9)

The fix in this PR should completely remove the section that sets the Windows Defender exclusion options from the template string built by the `pack win` command for use with NSIS.