### PR TITLE
Update win.ts and fix error by adding quotation marks

### DIFF
--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -316,7 +316,7 @@ the CLI should already exist in a directory named after the CLI that is the root
 
         await move(buildConfig.workspace({arch, platform: 'win32'}), path.join(installerBase, 'client'))
         await exec(
-          `makensis ${installerBase}/${config.bin}.nsi | grep -v "\\[compress\\]" | grep -v "^File: Descending to"`,
+          `makensis "${installerBase}/${config.bin}.nsi" | grep -v "\\[compress\\]" | grep -v "^File: Descending to"`,
         )
         const templateKey = templateShortKey('win32', {
           arch,


### PR DESCRIPTION
If the path to the project contains a whitespace, makensis fails without any info. Adding quotation marks will fix the failing part.