### PR TITLE
fix: respect tsconfig outDir when generating hook

### DIFF
--- a/src/commands/generate/hook.ts
+++ b/src/commands/generate/hook.ts
@@ -1,4 +1,6 @@
 import {Args, Flags} from '@oclif/core'
+import * as fs from 'fs-extra'
+import {resolve} from 'node:path'
 
 import CommandBase from './../../command-base'
 
@@ -16,11 +18,14 @@ export default class GenerateHook extends CommandBase {
 
   async run(): Promise<void> {
     const {args, flags} = await this.parse(GenerateHook)
+    const tsConfigPath = resolve(process.cwd(), 'tsconfig.json')
+    const tsConfig = await fs.readJSON(tsConfigPath).catch(() => ({}))
 
     await super.generate('hook', {
       event: flags.event,
       force: flags.force,
       name: args.name,
+      outDir: tsConfig.compilerOptions?.outDir ?? 'dist',
     })
   }
 }

--- a/src/generators/hook.ts
+++ b/src/generators/hook.ts
@@ -9,6 +9,7 @@ const {version} = require('../../package.json')
 
 export interface Options extends GeneratorOptions {
   event: string
+  outDir: string
 }
 
 export default class Hook extends Generator {
@@ -46,7 +47,7 @@ export default class Hook extends Generator {
     this.pjson.oclif = this.pjson.oclif || {}
     this.pjson.oclif.hooks = this.pjson.oclif.hooks || {}
     const hooks = this.pjson.oclif.hooks
-    const p = `./dist/hooks/${this.options.event}/${this.options.name}`
+    const p = `./${this.options.outDir}/hooks/${this.options.event}/${this.options.name}`
     if (hooks[this.options.event]) {
       hooks[this.options.event] = castArray(hooks[this.options.event])
       hooks[this.options.event] = [...hooks[this.options.event], p]


### PR DESCRIPTION
Respect tsconfig.json's `outDir` when composing path for generated hook


Fixes #1196

@W-14251792@