### PR TITLE
fix: force local paths when extracting on win32

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -91,7 +91,9 @@ export async function build(
     await emptyDir(c.workspace())
     const tarballNewLocation = path.join(c.workspace(), path.basename(tarball))
     await move(tarball, tarballNewLocation)
-    await exec(`tar -xzf "${tarballNewLocation}"`, {cwd: c.workspace()})
+    let tarCommand = `tar -xzf "${tarballNewLocation}"`
+    if (process.platform === 'win32') tarCommand += ' --force-local';
+    await exec(tarCommand, {cwd: c.workspace()})
     const files = await readdir(path.join(c.workspace(), 'package'), {withFileTypes: true})
     await Promise.all(
       files.map((i) => move(path.join(c.workspace(), 'package', i.name), path.join(c.workspace(), i.name))),


### PR DESCRIPTION
Currently oclif/oclif uses a lot of bash in order to build applications and natively does not support windows runners such as cmd and pwsh. However, this can be worked around using wsl or github actions `bash` runner (even on windows machines).

Almost everything works and allows us to build with it in these bash environments, however, the only step that fails is this extract step because a Windows path will look like `C:\some\path` and tar will natevely interpret anything with a `:` as an IP: https://superuser.com/questions/1720172/what-does-tar-cannot-connect-to-resolve-failed-mean

We can't use this for win/macOS runners however as the `tar` cli in there does not support it: https://github.com/r-lib/remotes/issues/171

This just adds the --force-local flag to windows builds making much easy to build on native windows runners.