### PR TITLE
feat: add `pnpm` to the list of supported package managers

### DIFF
--- a/docs/generate.md
+++ b/docs/generate.md
@@ -32,7 +32,7 @@ FLAGS
       --owner=<value>             Supply answer for prompt: Who is the GitHub owner of repository
                                   (https://github.com/OWNER/repo)
       --package-manager=<option>  Supply answer for prompt: Select a package manager
-                                  <options: npm|yarn>
+                                  <options: npm|yarn|pnpm>
       --repository=<value>        Supply answer for prompt: What is the GitHub name of repository
                                   (https://github.com/owner/REPO)
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -90,8 +90,8 @@ const FLAGGABLE_PROMPTS = {
   },
   'package-manager': {
     message: 'Select a package manager',
-    options: ['npm', 'yarn'],
-    validate: (d: string) => ['npm', 'yarn'].includes(d) || 'Invalid package manager',
+    options: ['npm', 'yarn', 'pnpm'],
+    validate: (d: string) => ['npm', 'yarn', 'pnpm'].includes(d) || 'Invalid package manager',
   },
   repository: {
     message: 'What is the GitHub name of repository (https://github.com/owner/REPO)',
@@ -214,10 +214,10 @@ export default class Generate extends GeneratorCommand<typeof Generate> {
       repository: `${owner}/${repository}`,
     }
 
-    if (packageManager === 'npm') {
+    if (packageManager !== 'yarn') {
       const scripts = (updatedPackageJSON.scripts || {}) as Record<string, string>
       updatedPackageJSON.scripts = Object.fromEntries(
-        Object.entries(scripts).map(([k, v]) => [k, v.replace('yarn', 'npm run')]),
+        Object.entries(scripts).map(([k, v]) => [k, v.replace('yarn', `${packageManager} run`)]),
       )
     }
 


### PR DESCRIPTION
When generating a new CLI, there's now only yarn and npm in the list. `pnpm` is quite popular and widely used, so It would be great to have `pnpm` option available in the list too.