### PR TITLE
fix: doc pretarball in help

### DIFF
--- a/src/commands/pack/deb.ts
+++ b/src/commands/pack/deb.ts
@@ -52,7 +52,8 @@ APT::FTPArchive::Release {
 }
 
 export default class PackDeb extends Command {
-  static description = 'Pack CLI into debian package.'
+  static description =
+    'Add a pretarball script to your package.json if you need to run any scripts before the tarball is created.'
 
   static flags = {
     compression: Flags.option({
@@ -70,6 +71,8 @@ export default class PackDeb extends Command {
       required: false,
     }),
   }
+
+  static summary = 'Pack CLI into debian package.'
 
   async run(): Promise<void> {
     if (process.platform !== 'linux') throw new Error('debian packing must be run on linux')

--- a/src/commands/pack/macos.ts
+++ b/src/commands/pack/macos.ts
@@ -138,7 +138,8 @@ exit 0
 }
 
 export default class PackMacos extends Command {
-  static description = 'Pack CLI into macOS .pkg'
+  static description =
+    'Add a pretarball script to your package.json if you need to run any scripts before the tarball is created.'
 
   static flags = {
     'additional-cli': Flags.string({
@@ -161,6 +162,8 @@ the CLI should already exist in a directory named after the CLI that is the root
       description: 'Comma-separated targets to pack (e.g.: darwin-x64,darwin-arm64).',
     }),
   }
+
+  static summary = 'Pack CLI into macOS .pkg'
 
   async run(): Promise<void> {
     if (process.platform !== 'darwin') this.error('must be run from macos')

--- a/src/commands/pack/tarballs.ts
+++ b/src/commands/pack/tarballs.ts
@@ -3,8 +3,9 @@ import {Command, Flags} from '@oclif/core'
 import * as Tarballs from '../../tarballs'
 
 export default class PackTarballs extends Command {
-  static description =
-    'This can be used to create oclif CLIs that use the system node or that come preloaded with a node binary.'
+  static description = `This can be used to create oclif CLIs that use the system node or that come preloaded with a node binary.
+
+Add a pretarball script to your package.json if you need to run any scripts before the tarball is created.`
 
   static flags = {
     parallel: Flags.boolean({description: 'Build tarballs in parallel.'}),

--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -224,7 +224,9 @@ exit $ret
 }
 
 export default class PackWin extends Command {
-  static description = `This command will produce unsigned installers unless you supply WINDOWS_SIGNING_PASS (prefixed with the name of your executable, e.g. OCLIF_WINDOWS_SIGNING_PASS) in the environment and have set the windows.name and windows.keypath properties in your package.json's oclif property.
+  static description = `You need to have 7zip and nsis installed on your machine in order to run this command.
+
+This command will produce unsigned installers unless you supply WINDOWS_SIGNING_PASS (prefixed with the name of your executable, e.g. OCLIF_WINDOWS_SIGNING_PASS) in the environment and have set the windows.name and windows.keypath properties in your package.json's oclif property.
 
 Add a pretarball script to your package.json if you need to run any scripts before the tarball is created.`
 

--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -224,8 +224,9 @@ exit $ret
 }
 
 export default class PackWin extends Command {
-  static description =
-    "This command will produce unsigned installers unless you supply WINDOWS_SIGNING_PASS (prefixed with the name of your executable, e.g. OCLIF_WINDOWS_SIGNING_PASS) in the environment and have set the windows.name and windows.keypath properties in your package.json's oclif property."
+  static description = `This command will produce unsigned installers unless you supply WINDOWS_SIGNING_PASS (prefixed with the name of your executable, e.g. OCLIF_WINDOWS_SIGNING_PASS) in the environment and have set the windows.name and windows.keypath properties in your package.json's oclif property.
+
+Add a pretarball script to your package.json if you need to run any scripts before the tarball is created.`
 
   static flags = {
     'additional-cli': Flags.string({

--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -224,7 +224,7 @@ exit $ret
 }
 
 export default class PackWin extends Command {
-  static description = `You need to have 7zip and nsis installed on your machine in order to run this command.
+  static description = `You need to have 7zip, nsis (makensis), and grep installed on your machine in order to run this command.
 
 This command will produce unsigned installers unless you supply WINDOWS_SIGNING_PASS (prefixed with the name of your executable, e.g. OCLIF_WINDOWS_SIGNING_PASS) in the environment and have set the windows.name and windows.keypath properties in your package.json's oclif property.
 


### PR DESCRIPTION
- Document `pretarball` script in the help for the `pack` commands
- Add note about prereqs for `oclif pack win`

Fixes https://github.com/oclif/oclif.github.io/issues/224
@W-15285420@