### PR TITLE
feat: Add init command

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -117,9 +117,7 @@ export default class Generate extends GeneratorCommand<typeof Generate> {
 
     const repoBinPath = join(repoPath, 'bin')
     const projectBinPath = join(location, 'bin')
-    if (!statSync(projectBinPath).isDirectory()) {
-      await mkdir(projectBinPath)
-    }
+    await mkdir(projectBinPath, {recursive: true})
 
     const binFiles = await readdir(repoBinPath)
     for (const binFile of binFiles) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -81,7 +81,7 @@ export default class Generate extends GeneratorCommand<typeof Generate> {
     }
 
     const bin = await this.getFlagOrPrompt({
-      defaultValue: location.split(sep).at(-1)!,
+      defaultValue: location.split(sep).at(-1) || '',
       name: 'bin',
       type: 'input',
     })

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -126,6 +126,7 @@ export default class Generate extends GeneratorCommand<typeof Generate> {
       ...packageJSON,
       bin: {[bin]: './bin/run.js'},
       oclif: {
+        commands: './dist/commands',
         ...packageJSON.oclif,
         bin,
         dirname: bin,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,167 @@
+/* eslint-disable unicorn/no-await-expression-member */
+import {Errors, Flags} from '@oclif/core'
+import chalk from 'chalk'
+import {existsSync, renameSync, statSync} from 'node:fs'
+import {readdir, rm, writeFile} from 'node:fs/promises'
+import {join, resolve, sep} from 'node:path'
+
+import {FlaggablePrompt, GeneratorCommand, exec, makeFlags, readPJSON} from '../generator'
+import {validateBin} from '../util'
+
+async function clone(repo: string, location: string): Promise<void> {
+  try {
+    await exec(`git clone https://github.com/oclif/${repo}.git "${location}" --depth=1`)
+  } catch (error) {
+    const err =
+      error instanceof Error
+        ? new Errors.CLIError(error)
+        : new Errors.CLIError('An error occurred while cloning the template repo')
+    throw err
+  }
+}
+
+const FLAGGABLE_PROMPTS = {
+  bin: {
+    message: 'Command bin name the CLI will export:',
+    validate: (d: string) => validateBin(d) || 'Invalid bin name',
+  },
+  'output-dir': {
+    message: 'Directory to build the CLI in:',
+    validate: (d: string) => existsSync(resolve(d)),
+  },
+  'package-manager': {
+    message: 'Select a package manager:',
+    options: ['npm', 'yarn', 'pnpm'],
+    validate: (d: string) => ['npm', 'pnpm', 'yarn'].includes(d) || 'Invalid package manager',
+  },
+} satisfies Record<string, FlaggablePrompt>
+
+export default class Generate extends GeneratorCommand<typeof Generate> {
+  static description = `This will clone the template repo and update package properties. For CommonJS, the 'oclif/hello-world' template will be used and for ESM, the 'oclif/hello-world-esm' template will be used.`
+
+  static examples = [
+    {
+      command: '<%= config.bin %> <%= command.id %> my-cli',
+      description: 'Generate a new CLI with prompts for all properties',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> my-cli --yes',
+      description: 'Automatically accept default values for all prompts',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> my-cli --module-type CommonJS --author "John Doe"',
+      description: 'Supply answers for specific prompts',
+    },
+    {
+      command: '<%= config.bin %> <%= command.id %> my-cli --module-type CommonJS --author "John Doe" --yes',
+      description: 'Supply answers for specific prompts and accept default values for the rest',
+    },
+  ]
+
+  static flaggablePrompts = FLAGGABLE_PROMPTS
+
+  static flags = {
+    ...makeFlags(FLAGGABLE_PROMPTS),
+    'module-type': Flags.option({
+      options: ['CommonJS', 'ESM'],
+    })({}),
+  }
+
+  static summary = 'Initialize a new oclif CLI'
+
+  async run(): Promise<void> {
+    const outputDir = await this.getFlagOrPrompt({defaultValue: './', name: 'output-dir', type: 'input'})
+    const location = resolve(outputDir)
+
+    this.log(`Initializing oclif in ${chalk.green(location)}`)
+
+    const packageJSON = (await readPJSON(location))!
+    if (!packageJSON) {
+      throw new Errors.CLIError(`Could not find a package.json file in ${location}`)
+    }
+
+    const bin = await this.getFlagOrPrompt({
+      defaultValue: location.split(sep).at(-1)!,
+      name: 'bin',
+      type: 'input',
+    })
+
+    let moduleType = this.flags['module-type']
+    if (!moduleType) {
+      if (packageJSON.type === 'module') {
+        moduleType = 'ESM'
+      } else if (packageJSON.type === 'commonjs') {
+        moduleType = 'CommonJS'
+      } else {
+        moduleType = await (
+          await import('@inquirer/select')
+        ).default({
+          choices: [
+            {name: 'CommonJS', value: 'CommonJS'},
+            {name: 'ESM', value: 'ESM'},
+          ],
+          message: 'Select a module type:',
+        })
+      }
+    }
+
+    this.log(`Using module type ${chalk.green(moduleType)}`)
+
+    const template = moduleType === 'ESM' ? 'hello-world-esm' : 'hello-world'
+    const repoPath = join(location, '_tmp-template')
+    await clone(template, repoPath)
+
+    const repoBinPath = join(repoPath, 'bin')
+    const binFiles = await readdir(repoBinPath)
+    for (const binFile of binFiles) {
+      const filePath = join(repoBinPath, binFile)
+      if (statSync(filePath).isFile()) {
+        renameSync(filePath, join(location, 'bin', binFile))
+      }
+    }
+
+    await rm(repoPath, {recursive: true})
+
+    const updatedPackageJSON = {
+      ...packageJSON,
+      bin: {[bin]: './bin/run.js'},
+      oclif: {
+        ...packageJSON.oclif,
+        bin,
+        dirname: bin,
+      },
+    }
+
+    await writeFile(join(location, 'package.json'), JSON.stringify(updatedPackageJSON, null, 2))
+
+    const installedDeps = Object.keys(packageJSON.dependencies || {})
+    if (!installedDeps.includes('@oclif/core')) {
+      let packageManager = this.flags['package-manager']
+      if (!packageManager) {
+        const rootFiles = await readdir(location)
+        if (rootFiles.includes('package-lock.json')) {
+          packageManager = 'npm'
+        } else if (rootFiles.includes('yarn.lock')) {
+          packageManager = 'yarn'
+        } else if (rootFiles.includes('pnpm-lock.yaml')) {
+          packageManager = 'pnpm'
+        } else {
+          packageManager = await (
+            await import('@inquirer/select')
+          ).default({
+            choices: [
+              {name: 'npm', value: 'npm'},
+              {name: 'yarn', value: 'yarn'},
+              {name: 'pnpm', value: 'pnpm'},
+            ],
+            message: 'Select a package manager:',
+          })
+        }
+      }
+
+      await exec(`${packageManager} install @oclif/core`, {cwd: location, silent: false})
+    }
+
+    this.log(`\nCreated CLI ${chalk.green(bin)}`)
+  }
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -40,24 +40,21 @@ const FLAGGABLE_PROMPTS = {
 } satisfies Record<string, FlaggablePrompt>
 
 export default class Generate extends GeneratorCommand<typeof Generate> {
-  static description = `This will clone the template repo and update package properties. For CommonJS, the 'oclif/hello-world' template will be used and for ESM, the 'oclif/hello-world-esm' template will be used.`
+  static description =
+    'This will add the necessary oclif bin files, add oclif config to package.json, and install @oclif/core if needed.'
 
   static examples = [
     {
-      command: '<%= config.bin %> <%= command.id %> my-cli',
-      description: 'Generate a new CLI with prompts for all properties',
+      command: '<%= config.bin %> <%= command.id %>',
+      description: 'Initialize a new CLI in the current directory with auto-detected module type and package manager',
     },
     {
-      command: '<%= config.bin %> <%= command.id %> my-cli --yes',
-      description: 'Automatically accept default values for all prompts',
+      command: '<%= config.bin %> <%= command.id %> --output-dir "/path/to/existing/project"',
+      description: 'Initialize a new CLI in a different directory',
     },
     {
-      command: '<%= config.bin %> <%= command.id %> my-cli --module-type CommonJS --author "John Doe"',
+      command: '<%= config.bin %> <%= command.id %> --module-type "ESM" --package-manager "npm"',
       description: 'Supply answers for specific prompts',
-    },
-    {
-      command: '<%= config.bin %> <%= command.id %> my-cli --module-type CommonJS --author "John Doe" --yes',
-      description: 'Supply answers for specific prompts and accept default values for the rest',
     },
   ]
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -166,7 +166,10 @@ export default class Generate extends GeneratorCommand<typeof Generate> {
         }
       }
 
-      await exec(`${packageManager} install @oclif/core`, {cwd: location, silent: false})
+      await exec(`${packageManager} ${packageManager === 'npm' ? 'install' : 'add'} @oclif/core`, {
+        cwd: location,
+        silent: false,
+      })
     }
 
     this.log(`\nCreated CLI ${chalk.green(bin)}`)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -25,15 +25,15 @@ const validPackageManagers = ['npm', 'yarn', 'pnpm']
 
 const FLAGGABLE_PROMPTS = {
   bin: {
-    message: 'Command bin name the CLI will export:',
+    message: 'Command bin name the CLI will export',
     validate: (d: string) => validateBin(d) || 'Invalid bin name',
   },
   'output-dir': {
-    message: 'Directory to build the CLI in:',
+    message: 'Directory to build the CLI in',
     validate: (d: string) => existsSync(resolve(d)),
   },
   'package-manager': {
-    message: 'Select a package manager:',
+    message: 'Select a package manager',
     options: validPackageManagers,
     validate: (d: string) => validPackageManagers.includes(d) || 'Invalid package manager',
   },
@@ -97,7 +97,7 @@ export default class Generate extends GeneratorCommand<typeof Generate> {
           await import('@inquirer/select')
         ).default({
           choices: validModuleTypes.map((type) => ({name: type, value: type})),
-          message: 'Select a module type:',
+          message: 'Select a module type',
         })
       }
     }
@@ -151,7 +151,7 @@ export default class Generate extends GeneratorCommand<typeof Generate> {
             await import('@inquirer/select')
           ).default({
             choices: validPackageManagers.map((manager) => ({name: manager, value: manager})),
-            message: 'Select a package manager:',
+            message: 'Select a package manager',
           })
         }
       }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -124,7 +124,10 @@ export default class Generate extends GeneratorCommand<typeof Generate> {
 
     const updatedPackageJSON = {
       ...packageJSON,
-      bin: {[bin]: './bin/run.js'},
+      bin: {
+        ...packageJSON.bin,
+        [bin]: './bin/run.js',
+      },
       oclif: {
         bin,
         commands: './dist/commands',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -126,10 +126,10 @@ export default class Generate extends GeneratorCommand<typeof Generate> {
       ...packageJSON,
       bin: {[bin]: './bin/run.js'},
       oclif: {
-        commands: './dist/commands',
-        ...packageJSON.oclif,
         bin,
+        commands: './dist/commands',
         dirname: bin,
+        ...packageJSON.oclif,
       },
     }
 

--- a/templates/src/init/dev.cmd.ejs
+++ b/templates/src/init/dev.cmd.ejs
@@ -1,0 +1,12 @@
+<% switch (moduleType) {
+  case 'ESM' : _%>
+@echo off
+
+node --loader ts-node/esm --no-warnings=ExperimentalWarning "%~dp0\dev" %*
+          <%_ break;
+  case 'CommonJS' : _%>
+@echo off
+
+node "%~dp0\dev" %*
+          <%_ break;
+  } _%>

--- a/templates/src/init/dev.js.ejs
+++ b/templates/src/init/dev.js.ejs
@@ -1,0 +1,17 @@
+<% switch (moduleType) {
+  case 'ESM' : _%>
+#!/usr/bin/env -S node --loader ts-node/esm --no-warnings=ExperimentalWarning
+
+import {execute} from '@oclif/core'
+await execute({development: true, dir: import.meta.url})
+          <%_ break;
+  case 'CommonJS' : _%>
+#!/usr/bin/env node_modules/.bin/ts-node
+
+// eslint-disable-next-line node/shebang, unicorn/prefer-top-level-await
+(async () => {
+  const oclif = await import('@oclif/core')
+  await oclif.execute({development: true, dir: __dirname})
+})()
+          <%_ break;
+  } _%>

--- a/templates/src/init/run.cmd.ejs
+++ b/templates/src/init/run.cmd.ejs
@@ -1,0 +1,3 @@
+@echo off
+
+node "%~dp0\run" %*

--- a/templates/src/init/run.js.ejs
+++ b/templates/src/init/run.js.ejs
@@ -1,0 +1,17 @@
+<% switch (moduleType) {
+  case 'ESM' : _%>
+#!/usr/bin/env node
+
+import {execute} from '@oclif/core'
+await execute({dir: import.meta.url})
+          <%_ break;
+  case 'CommonJS' : _%>
+#!/usr/bin/env node
+
+// eslint-disable-next-line unicorn/prefer-top-level-await
+(async () => {
+  const oclif = await import('@oclif/core')
+  await oclif.execute({development: false, dir: __dirname})
+})()
+          <%_ break;
+  } _%>


### PR DESCRIPTION
This adds a new command, `init`, that adds the necessary files and configuration to an existing npm project. It attempts to auto-detect the module type and package manager being used, falling back to a prompt if necessary. Usage is covered in the examples. 

Addresses #999