### PR TITLE
fix(readme): read tsconfigs as JSONC instead of JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "normalize-package-data": "^6",
     "semver": "^7.6.0",
     "sort-package-json": "^2.10.0",
+    "tiny-jsonc": "^1.0.1",
     "validate-npm-package-name": "^5.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6020,6 +6020,11 @@ through2@^4.0.0:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
+tiny-jsonc@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tiny-jsonc/-/tiny-jsonc-1.0.1.tgz#71de47c9d812b411e87a9f3ab4a5fe42cd8d8f9c"
+  integrity sha512-ik6BCxzva9DoiEfDX/li0L2cWKPPENYvixUprFdl3YPi4bZZUhDnNI9YUkacrv+uIG90dnxR5mNqaoD6UhD6Bw==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"


### PR DESCRIPTION
When a plugin's tsconfig file contains comments or trailing commas, `oclif readme` fails to read the tsconfig file because it's expecting well-formed JSON, not JSONC. As far as I can tell, it's trying to read the compilerOptions.outDir value from the tsconfig, but only to check if the output folder exists. It logs a warning, but the command seems to find everything it's supposed to despite the warning.

In this PR, I use [tiny-jsonc](https://www.npmjs.com/package/tiny-jsonc) to parse the tsconfig instead of JSON.parse. The code is more verbose, and I'm not sure introducing a new dependency just for a clearer warning message is worth it.

An alternative might me to load the oclif.commands value from package.json and check that instead. I don't know if that's similar enough to the existing check, though.