### PR TITLE
chore: bump plugin-not-found version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@inquirer/select": "^2.3.2",
     "@oclif/core": "^3.26.5",
     "@oclif/plugin-help": "^6.0.21",
-    "@oclif/plugin-not-found": "^3.1.8",
+    "@oclif/plugin-not-found": "^3.1.9",
     "@oclif/plugin-warn-if-update-available": "^3.0.18",
     "async-retry": "^1.3.3",
     "chalk": "^4",


### PR DESCRIPTION
Probably the last one of this series. 
[plugin-not-found](https://github.com/oclif/plugin-not-found/releases/tag/3.1.9) has updated its dependencies with fixed versions of lodash vulnerability.
Just bumping this version to include the new updates