### PR TITLE
fix: launch config for ESM

### DIFF
--- a/templates/cli/commonjs/.vscode/launch.json.ejs
+++ b/templates/cli/commonjs/.vscode/launch.json.ejs
@@ -13,7 +13,7 @@
       "request": "launch",
       "name": "Execute Command",
       "skipFiles": ["<node_internals>/**"],
-      "program": "${workspaceFolder}/bin/dev",
+      "program": "${workspaceFolder}/bin/dev.js",
       "args": ["hello", "world"]
     }
   ]

--- a/templates/cli/esm/.vscode/launch.json.ejs
+++ b/templates/cli/esm/.vscode/launch.json.ejs
@@ -1,0 +1,22 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach",
+      "port": 9229,
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Execute Command",
+      "skipFiles": ["<node_internals>/**"],
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["--loader", "ts-node/esm", "--no-warnings=ExperimentalWarning"],
+      "program": "${workspaceFolder}/bin/dev.js",
+      "args": ["hello", "world"]
+    }
+  ]
+}


### PR DESCRIPTION
Generate separate `.vscode/launch.json` for ESM and CommonJS

**Testing**

- `bin/dev.js generate launch-test-cjs --output-dir ~/code --yes --module-type CommonJS`
- `bin/dev.js generate launch-test-esm --output-dir ~/code --yes --module-type ESM`
- open `launch-test-cjs` in vscode, put breakpoint in `src/commands/hello/world.ts`, launch `Execute Command` from debugger panel. Debugger should pause on breakpoint
- open `launch-test-esm` in vscode, put breakpoint in `src/commands/hello/world.ts`, launch `Execute Command` from debugger panel. Debugger should pause on breakpoint

Fixes #1438 

@W-15959529@