### PR TITLE
fix: allow upload to succeed without buildmanifest

### DIFF
--- a/src/commands/upload/tarballs.ts
+++ b/src/commands/upload/tarballs.ts
@@ -1,4 +1,4 @@
-import {Command, Flags, Interfaces} from '@oclif/core'
+import {Command, Flags, Interfaces, ux} from '@oclif/core'
 import * as fs from 'node:fs'
 
 import aws from '../../aws'
@@ -7,7 +7,7 @@ import * as Tarballs from '../../tarballs'
 import {commitAWSDir, templateShortKey} from '../../upload-util'
 
 export default class UploadTarballs extends Command {
-  static description = 'Upload an oclif CLI to S3.'
+  static description = 'Upload an oclif CLI to S3. Requires s3 host and bucket to be configured.'
 
   static flags = {
     root: Flags.string({char: 'r', default: '.', description: 'Path to oclif CLI root.', required: true}),
@@ -65,17 +65,25 @@ export default class UploadTarballs extends Command {
         })
       }
 
-      const manifest = templateShortKey('manifest', shortKeyInputs)
-      const cloudKey = `${commitAWSDir(config.version, buildConfig.gitSha, s3Config)}/${manifest}`
+      const maybeUploadManifest = async () => {
+        const manifest = templateShortKey('manifest', shortKeyInputs)
+        const cloudKey = `${commitAWSDir(config.version, buildConfig.gitSha, s3Config)}/${manifest}`
+        const local = dist(manifest)
+        if (fs.existsSync(local)) {
+          return aws.s3.uploadFile(dist(manifest), {
+            ...S3Options,
+            CacheControl: 'max-age=86400',
+            ContentType: 'application/json',
+            Key: cloudKey,
+          })
+        }
+
+        ux.warn(`Cannot find buildmanifest ${local}. CLI will not be able to update itself.`)
+      }
 
       await Promise.all([
         releaseTarballs('.tar.gz'),
-        aws.s3.uploadFile(dist(manifest), {
-          ...S3Options,
-          CacheControl: 'max-age=86400',
-          ContentType: 'application/json',
-          Key: cloudKey,
-        }),
+        maybeUploadManifest(),
         ...(xz ? [releaseTarballs('.tar.xz')] : []),
       ])
     }

--- a/src/commands/upload/tarballs.ts
+++ b/src/commands/upload/tarballs.ts
@@ -7,7 +7,7 @@ import * as Tarballs from '../../tarballs'
 import {commitAWSDir, templateShortKey} from '../../upload-util'
 
 export default class UploadTarballs extends Command {
-  static description = 'Upload an oclif CLI to S3. Requires s3 host and bucket to be configured.'
+  static description = 'Upload an oclif CLI to S3.'
 
   static flags = {
     root: Flags.string({char: 'r', default: '.', description: 'Path to oclif CLI root.', required: true}),

--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -1,4 +1,4 @@
-import {Interfaces} from '@oclif/core'
+import {Interfaces, ux} from '@oclif/core'
 import findYarnWorkspaceRoot from 'find-yarn-workspace-root'
 import {copy, emptyDir, move, readJSON, remove, writeJSON} from 'fs-extra'
 import {exec as execSync} from 'node:child_process'
@@ -94,6 +94,10 @@ export async function build(c: BuildConfig, options: BuildOptions = {}): Promise
   await pretarball(c)
   if (options.pruneLockfiles) {
     await removeLockfiles(c)
+  }
+
+  if (!c.updateConfig.s3?.host || !c.updateConfig.s3?.bucket) {
+    ux.warn('No S3 bucket or host configured. CLI will not be able to update itself.')
   }
 
   const targetsToBuild = c.targets.filter((t) => !options.platform || options.platform === t.platform)


### PR DESCRIPTION
- Warn about missing `buildmanifest` during `pack` if s3 bucket or host are not set
- Allow `upload` to succeed when `buildmanifest` doesn't exist and print warning

Fixes #1447 
@W-15993332@