### PR TITLE
Add quotes to windows signing pass

### DIFF
--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -381,7 +381,7 @@ async function signWindows(
     '-pkcs12',
     windows.keypath,
     '-pass',
-    pass,
+    `"${pass}"`,
     '-n',
     `"${windows.name}"`,
     '-i',


### PR DESCRIPTION
With some encryption passwords, command fails