### PR TITLE
fix: pass in respectNoCacheDefault to help

### DIFF
--- a/src/readme-generator.ts
+++ b/src/readme-generator.ts
@@ -180,7 +180,7 @@ export default class ReadmeGenerator {
     const title = render(c.summary ?? c.description ?? '', {command: c, config: this.config})
       .trim()
       .split('\n')[0]
-    const help = new HelpClass(this.config, {maxWidth: columns, stripAnsi: true})
+    const help = new HelpClass(this.config, {maxWidth: columns, respectNoCacheDefault: true, stripAnsi: true})
     const wrapper = new HelpCompatibilityWrapper(help)
 
     const header = () => {


### PR DESCRIPTION
Provide `respectNoCacheDefault` option to help class to ignore any defaults for flags that have `noCacheDefault` property

Depends on https://github.com/oclif/core/pull/1212

@W-16883857@
https://github.com/forcedotcom/cli/issues/3041 