### PR TITLE
fix: improve logging in promote

### DIFF
--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -15,7 +15,7 @@ export default class Promote extends Command {
     channel: Flags.string({default: 'stable', description: 'Channel to promote to.', required: true}),
     deb: Flags.boolean({char: 'd', description: 'Promote debian artifacts.'}),
     'dry-run': Flags.boolean({
-      description: 'Show what would be promoted without actually promoting.',
+      description: 'Run the command without uploading to S3 or copying versioned tarballs/installers to channel.',
     }),
     'ignore-missing': Flags.boolean({
       description: 'Ignore missing tarballs/installers and continue promoting the rest.',
@@ -38,6 +38,8 @@ export default class Promote extends Command {
         "--ignore-missing flag is being used - This command will continue to run even if a promotion fails because it doesn't exist",
       )
     }
+
+    this.log(`Promoting v${flags.version} (${flags.sha}) to ${flags.channel} channel\n`)
 
     const buildConfig = await Tarballs.buildConfig(flags.root, {targets: flags?.targets?.split(',')})
     const {config, s3Config} = buildConfig
@@ -111,7 +113,14 @@ export default class Promote extends Command {
           },
         ),
         ...(flags.indexes
-          ? [appendToIndex({...indexDefaults, filename: unversionedTarGzName, originalUrl: versionedTarGzKey})]
+          ? [
+              appendToIndex({
+                ...indexDefaults,
+                dryRun: flags['dry-run'],
+                filename: unversionedTarGzName,
+                originalUrl: versionedTarGzKey,
+              }),
+            ]
           : []),
       ])
     }
@@ -143,7 +152,14 @@ export default class Promote extends Command {
           },
         ),
         ...(flags.indexes
-          ? [appendToIndex({...indexDefaults, filename: unversionedTarXzName, originalUrl: versionedTarXzKey})]
+          ? [
+              appendToIndex({
+                ...indexDefaults,
+                dryRun: flags['dry-run'],
+                filename: unversionedTarXzName,
+                originalUrl: versionedTarXzKey,
+              }),
+            ]
           : []),
       ])
     }
@@ -170,7 +186,14 @@ export default class Promote extends Command {
               },
             ),
             ...(flags.indexes
-              ? [appendToIndex({...indexDefaults, filename: unversionedPkg, originalUrl: darwinCopySource})]
+              ? [
+                  appendToIndex({
+                    ...indexDefaults,
+                    dryRun: flags['dry-run'],
+                    filename: unversionedPkg,
+                    originalUrl: darwinCopySource,
+                  }),
+                ]
               : []),
           ])
         }),
@@ -200,7 +223,14 @@ export default class Promote extends Command {
               },
             ),
             ...(flags.indexes
-              ? [appendToIndex({...indexDefaults, filename: unversionedExe, originalUrl: winCopySource})]
+              ? [
+                  appendToIndex({
+                    ...indexDefaults,
+                    dryRun: flags['dry-run'],
+                    filename: unversionedExe,
+                    originalUrl: winCopySource,
+                  }),
+                ]
               : []),
           ])
           ux.action.stop('successfully')

--- a/src/commands/upload/macos.ts
+++ b/src/commands/upload/macos.ts
@@ -11,6 +11,7 @@ export default class UploadMacos extends Command {
   static description = 'Upload macos installers built with `pack macos`.'
 
   static flags = {
+    'dry-run': Flags.boolean({description: 'Run the command without uploading to S3.'}),
     root: Flags.string({char: 'r', default: '.', description: 'Path to oclif CLI root.', required: true}),
     targets: Flags.string({
       char: 't',
@@ -39,7 +40,13 @@ export default class UploadMacos extends Command {
       const localPkg = dist(`macos/${templateKey}`)
 
       if (fs.existsSync(localPkg))
-        await aws.s3.uploadFile(localPkg, {...S3Options, CacheControl: 'max-age=86400', Key: cloudKey})
+        await aws.s3.uploadFile(
+          localPkg,
+          {...S3Options, CacheControl: 'max-age=86400', Key: cloudKey},
+          {
+            dryRun: flags['dry-run'],
+          },
+        )
       else
         this.error('Cannot find macOS pkg', {
           suggestions: ['Run "oclif pack macos" before uploading'],

--- a/src/commands/upload/win.ts
+++ b/src/commands/upload/win.ts
@@ -10,6 +10,7 @@ export default class UploadWin extends Command {
   static description = 'Upload windows installers built with `pack win`.'
 
   static flags = {
+    'dry-run': Flags.boolean({description: 'Run the command without uploading to S3.'}),
     root: Flags.string({char: 'r', default: '.', description: 'Path to oclif CLI root.', required: true}),
     targets: Flags.string({description: 'Comma-separated targets to pack (e.g.: win32-x64,win32-x86,win32-arm64).'}),
   }
@@ -50,7 +51,13 @@ export default class UploadWin extends Command {
       const localExe = dist(`win32/${templateKey}`)
       const cloudKey = `${cloudKeyBase}/${templateKey}`
       if (fs.existsSync(localExe))
-        await aws.s3.uploadFile(localExe, {...S3Options, CacheControl: 'max-age=86400', Key: cloudKey})
+        await aws.s3.uploadFile(
+          localExe,
+          {...S3Options, CacheControl: 'max-age=86400', Key: cloudKey},
+          {
+            dryRun: flags['dry-run'],
+          },
+        )
     }
 
     await Promise.all([uploadWin('x64'), uploadWin('x86'), uploadWin('arm64')])

--- a/src/version-indexes.ts
+++ b/src/version-indexes.ts
@@ -39,6 +39,7 @@ const sortVersionsObjectByKeysDesc = (input: VersionsObject, keyLimit?: number):
 
 // appends to an existing file (or writes a new one) with the versions in descending order, with an optional limit from the pjson file
 export const appendToIndex = async (input: {
+  dryRun?: boolean
   filename: string
   maxAge: string
   originalUrl: string
@@ -86,12 +87,18 @@ export const appendToIndex = async (input: {
   )
 
   // put the file back in the same place
-  await aws.s3.uploadFile(jsonFileName, {
-    ACL: s3Config.acl ?? ObjectCannedACL.public_read,
-    Bucket: s3Config.bucket,
-    CacheControl: maxAge,
-    Key: key,
-  })
+  await aws.s3.uploadFile(
+    jsonFileName,
+    {
+      ACL: s3Config.acl ?? ObjectCannedACL.public_read,
+      Bucket: s3Config.bucket,
+      CacheControl: maxAge,
+      Key: key,
+    },
+    {
+      dryRun: input.dryRun,
+    },
+  )
   // cleans up local fs
   await fs.remove(jsonFileName)
 }


### PR DESCRIPTION
- Improve logging in `oclif promote`
- Add `--dry-run` flag to following commands:
  - `oclif promote`
  - `oclif upload deb`
  - `oclif upload macos`
  - `oclif upload tarballs`
  - `oclif upload win`


```
❯ ~/repos/oclif/oclif/bin/run.js promote --macos --sha 0cbb3a0 --channel stable --version 2.60.13 --dry-run --win --xz --deb --indexes
Promoting v2.60.13 (0cbb3a0) to stable channel

> sf-linux-x64-buildmanifest
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-linux-x64-buildmanifest
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-linux-x64-buildmanifest

> sf-linux-x64.tar.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-linux-x64.tar.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.gz

> sf-linux-arm-buildmanifest
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-linux-arm-buildmanifest
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-linux-arm-buildmanifest

> sf-linux-arm.tar.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-linux-arm.tar.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-linux-arm.tar.gz

> sf-linux-arm64-buildmanifest
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-linux-arm64-buildmanifest
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-linux-arm64-buildmanifest

> sf-linux-arm64.tar.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-linux-arm64.tar.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-linux-arm64.tar.gz

> sf-win32-x64-buildmanifest
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-win32-x64-buildmanifest
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-win32-x64-buildmanifest

> sf-win32-x64.tar.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-win32-x64.tar.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-win32-x64.tar.gz

> sf-win32-x86-buildmanifest
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-win32-x86-buildmanifest
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-win32-x86-buildmanifest

> sf-win32-x86.tar.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-win32-x86.tar.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-win32-x86.tar.gz

> sf-win32-arm64-buildmanifest
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-win32-arm64-buildmanifest
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-win32-arm64-buildmanifest

> sf-win32-arm64.tar.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-win32-arm64.tar.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-win32-arm64.tar.gz

> sf-darwin-x64-buildmanifest
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-darwin-x64-buildmanifest
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-darwin-x64-buildmanifest

> sf-darwin-x64.tar.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-darwin-x64.tar.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-darwin-x64.tar.gz

> sf-darwin-arm64-buildmanifest
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-darwin-arm64-buildmanifest
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-darwin-arm64-buildmanifest

> sf-darwin-arm64.tar.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-darwin-arm64.tar.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-darwin-arm64.tar.gz

> sf-linux-x64.tar.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-linux-x64.tar.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.xz

> sf-linux-arm.tar.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-linux-arm.tar.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-linux-arm.tar.xz

> sf-linux-arm64.tar.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-linux-arm64.tar.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-linux-arm64.tar.xz

> sf-win32-x64.tar.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-win32-x64.tar.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-win32-x64.tar.xz

> sf-win32-x86.tar.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-win32-x86.tar.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-win32-x86.tar.xz

> sf-win32-arm64.tar.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-win32-arm64.tar.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-win32-arm64.tar.xz

> sf-darwin-x64.tar.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-darwin-x64.tar.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-darwin-x64.tar.xz

> sf-darwin-arm64.tar.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-darwin-arm64.tar.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-darwin-arm64.tar.xz

> sf-x64.pkg
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-x64.pkg
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-x64.pkg

> sf-arm64.pkg
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-arm64.pkg
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-arm64.pkg

> sf-x64.exe
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-x64.exe
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-x64.exe

> sf-x86.exe
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-x86.exe
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-x86.exe

> sf-arm64.exe
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/sf-v2.60.13-0cbb3a0-arm64.exe
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/sf-arm64.exe

> media/salesforce-cli/sf/channels/stable/apt/sf_2.61.0.9988229-1_amd64.deb
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/sf_2.61.0.9988229-1_amd64.deb
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/sf_2.61.0.9988229-1_amd64.deb

> media/salesforce-cli/sf/channels/stable/apt/./sf_2.61.0.9988229-1_amd64.deb
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/sf_2.61.0.9988229-1_amd64.deb
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/./sf_2.61.0.9988229-1_amd64.deb

> media/salesforce-cli/sf/channels/stable/apt/sf_2.61.0.9988229-1_armel.deb
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/sf_2.61.0.9988229-1_armel.deb
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/sf_2.61.0.9988229-1_armel.deb

> media/salesforce-cli/sf/channels/stable/apt/./sf_2.61.0.9988229-1_armel.deb
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/sf_2.61.0.9988229-1_armel.deb
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/./sf_2.61.0.9988229-1_armel.deb

> media/salesforce-cli/sf/channels/stable/apt/sf_2.61.0.9988229-1_arm64.deb
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/sf_2.61.0.9988229-1_arm64.deb
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/sf_2.61.0.9988229-1_arm64.deb

> media/salesforce-cli/sf/channels/stable/apt/./sf_2.61.0.9988229-1_arm64.deb
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/sf_2.61.0.9988229-1_arm64.deb
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/./sf_2.61.0.9988229-1_arm64.deb

> media/salesforce-cli/sf/channels/stable/apt/Packages.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Packages.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/Packages.gz

> media/salesforce-cli/sf/channels/stable/apt/./Packages.gz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Packages.gz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/./Packages.gz

> media/salesforce-cli/sf/channels/stable/apt/Packages.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Packages.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/Packages.xz

> media/salesforce-cli/sf/channels/stable/apt/./Packages.xz
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Packages.xz
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/./Packages.xz

> media/salesforce-cli/sf/channels/stable/apt/Packages.bz2
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Packages.bz2
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/Packages.bz2

> media/salesforce-cli/sf/channels/stable/apt/./Packages.bz2
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Packages.bz2
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/./Packages.bz2

> media/salesforce-cli/sf/channels/stable/apt/Release
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Release
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/Release

> media/salesforce-cli/sf/channels/stable/apt/./Release
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Release
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/./Release

> media/salesforce-cli/sf/channels/stable/apt/InRelease
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/InRelease
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/InRelease

> media/salesforce-cli/sf/channels/stable/apt/./InRelease
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/InRelease
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/./InRelease

> media/salesforce-cli/sf/channels/stable/apt/Release.gpg
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Release.gpg
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/Release.gpg

> media/salesforce-cli/sf/channels/stable/apt/./Release.gpg
  action: copy
  source: s3://dfc-data-production/media/salesforce-cli/sf/versions/2.60.13/0cbb3a0/apt/Release.gpg
  target: s3://dfc-data-production/media/salesforce-cli/sf/channels/stable/apt/./Release.gpg

> sf-win32-arm64-tar-gz.json
  action: upload
  source: sf-win32-arm64-tar-gz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-win32-arm64-tar-gz.json

> sf-linux-arm64-tar-gz.json
  action: upload
  source: sf-linux-arm64-tar-gz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-linux-arm64-tar-gz.json

> sf-linux-arm64-tar-xz.json
  action: upload
  source: sf-linux-arm64-tar-xz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-linux-arm64-tar-xz.json

> sf-arm64-pkg.json
  action: upload
  source: sf-arm64-pkg.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-arm64-pkg.json

> sf-linux-x64-tar-xz.json
  action: upload
  source: sf-linux-x64-tar-xz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-linux-x64-tar-xz.json

> sf-linux-arm-tar-xz.json
  action: upload
  source: sf-linux-arm-tar-xz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-linux-arm-tar-xz.json

> sf-linux-x64-tar-gz.json
  action: upload
  source: sf-linux-x64-tar-gz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-linux-x64-tar-gz.json

> sf-win32-x86-tar-gz.json
  action: upload
  source: sf-win32-x86-tar-gz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-win32-x86-tar-gz.json

> sf-arm64-exe.json
  action: upload
  source: sf-arm64-exe.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-arm64-exe.json

> sf-win32-x86-tar-xz.json
  action: upload
  source: sf-win32-x86-tar-xz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-win32-x86-tar-xz.json

> sf-darwin-x64-tar-gz.json
  action: upload
  source: sf-darwin-x64-tar-gz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-darwin-x64-tar-gz.json

> sf-win32-x64-tar-xz.json
  action: upload
  source: sf-win32-x64-tar-xz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-win32-x64-tar-xz.json

> sf-x64-exe.json
  action: upload
  source: sf-x64-exe.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-x64-exe.json

> sf-win32-x64-tar-gz.json
  action: upload
  source: sf-win32-x64-tar-gz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-win32-x64-tar-gz.json

> sf-x64-pkg.json
  action: upload
  source: sf-x64-pkg.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-x64-pkg.json

> sf-darwin-x64-tar-xz.json
  action: upload
  source: sf-darwin-x64-tar-xz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-darwin-x64-tar-xz.json

> sf-darwin-arm64-tar-gz.json
  action: upload
  source: sf-darwin-arm64-tar-gz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-darwin-arm64-tar-gz.json

> sf-linux-arm-tar-gz.json
  action: upload
  source: sf-linux-arm-tar-gz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-linux-arm-tar-gz.json

> sf-win32-arm64-tar-xz.json
  action: upload
  source: sf-win32-arm64-tar-xz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-win32-arm64-tar-xz.json

> sf-darwin-arm64-tar-xz.json
  action: upload
  source: sf-darwin-arm64-tar-xz.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-darwin-arm64-tar-xz.json

> sf-x86-exe.json
  action: upload
  source: sf-x86-exe.json
  target: s3://dfc-data-production/media/salesforce-cli/sf/versions/sf-x86-exe.json
```