### PR TITLE
fix: add explicit error when `files` is missing from package.json (#1577)

### DIFF
--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -98,10 +98,11 @@ export default class Manifest extends Command {
 
     if (!Array.isArray(plugin.pjson.files)) {
       this.error('The package.json has to contain a "files" array', {
-        suggestions: ['Add a "files" property in the package.json listing the paths to the files that should be included in the published package'],
-        ref: 'https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files'
+        ref: 'https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files',
+        suggestions: [
+          'Add a "files" property in the package.json listing the paths to the files that should be included in the published package',
+        ],
       })
-      return
     }
 
     const dotfile = plugin.pjson.files.find((f: string) => f.endsWith('.oclif.manifest.json'))

--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -96,6 +96,14 @@ export default class Manifest extends Command {
       await plugin.load()
     }
 
+    if (!Array.isArray(plugin.pjson.files)) {
+      this.error('The package.json has to contain a "files" array', {
+        suggestions: ['Add a "files" property in the package.json listing the paths to the files that should be included in the published package'],
+        ref: 'https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files'
+      })
+      return
+    }
+
     const dotfile = plugin.pjson.files.find((f: string) => f.endsWith('.oclif.manifest.json'))
     const file = path.join(plugin.root, `${dotfile ? '.' : ''}oclif.manifest.json`)
 


### PR DESCRIPTION
If `files` is missing from the package.json, `oclif manifest` would throw an unhelpful error

```
TypeError: Cannot read properties of undefined (reading 'find')
```

This makes sure that the user knows how to fix the issue