### PR TITLE
Introducing oclif CLI Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Version](https://img.shields.io/npm/v/oclif.svg)](https://npmjs.org/package/oclif)
 [![Downloads/week](https://img.shields.io/npm/dw/oclif.svg)](https://npmjs.org/package/oclif/oclif)
 [![License](https://img.shields.io/npm/l/oclif.svg)](https://github.com/oclif/oclif/blob/main/package.json)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20oclif%20CLI%20Guru-006BFF)](https://gurubase.io/g/oclif-cli)
 
 <!-- toc -->
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [oclif CLI Guru](https://gurubase.io/g/oclif-cli) to Gurubase. oclif CLI Guru uses the data from this repo and data from the [docs](http://oclif.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "oclif CLI Guru", which highlights that oclif CLI now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable oclif CLI Guru in Gurubase, just let me know that's totally fine.
