### PR TITLE
Feat: allow for a custom tsconfig path during readme generation

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -52,6 +52,10 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
     version: Flags.string({
       description: 'Version to use in readme links. Defaults to the version in package.json.',
     }),
+    'tsconfig-path': Flags.string({
+      default: 'tsconfig.json',
+      description: 'Path to the tsconfig file',
+    }),
   }
 
   static summary = 'Adds commands to README.md in current directory.'
@@ -63,7 +67,7 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
     this.flags = flags
     this.flags['plugin-directory'] ??= process.cwd()
     const readmePath = path.resolve(this.flags['plugin-directory'], flags['readme-path'])
-    const tsConfigPath = path.resolve(this.flags['plugin-directory'], 'tsconfig.json')
+    const tsConfigPath = path.resolve(this.flags['plugin-directory'], flags['tsconfig-path'])
     if (await fs.pathExists(tsConfigPath)) {
       const {default: JSONC} = await import('tiny-jsonc')
       const tsConfigRaw = await fs.readFile(tsConfigPath, 'utf8')


### PR DESCRIPTION
👋  I'd like the ability to point the tsconfig file at a different filename when running generate-readme e.g. `my-tsconfig.json`

I've added a flag following the same format and description as the README path.

Thanks!