### PR TITLE
fix: update onRelease workflow template to include build and prepack steps

### DIFF
--- a/templates/cli/shared/.github/workflows/onRelease.yml.ejs
+++ b/templates/cli/shared/.github/workflows/onRelease.yml.ejs
@@ -13,6 +13,9 @@ jobs:
         with:
           node-version: latest
       - run: <%- install %>
+      - run: <%- run %> build
+      - run: <%- run %> prepack
       - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c
         with:
           token: ${{ secrets.NPM_TOKEN }}
+      - run: <%- run %> postpack


### PR DESCRIPTION
fix: #1663

This pull request includes changes to the release workflow in the `onRelease.yml.ejs` file. The most important changes involve adding steps to the build process.

Enhancements to the build process:

* [`templates/cli/shared/.github/workflows/onRelease.yml.ejs`](diffhunk://#diff-15f9e65216eab68234996f9d4ee7722e043b6c259cb00234dac2f40eb5d5bab3R16-R21): Added steps to run `build`, `prepack`, and `postpack` commands in the release workflow.