### PR TITLE
fix: include `nodeOptions` in win installer bin

### DIFF
--- a/docs/generate.md
+++ b/docs/generate.md
@@ -64,7 +64,7 @@ EXAMPLES
     $ oclif generate my-cli --module-type CommonJS --author "John Doe" --yes
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/generate.ts)_
 
 ## `oclif generate command NAME`
 
@@ -85,7 +85,7 @@ DESCRIPTION
   Add a command to an existing CLI or plugin.
 ```
 
-_See code: [src/commands/generate/command.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/generate/command.ts)_
+_See code: [src/commands/generate/command.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/generate/command.ts)_
 
 ## `oclif generate hook NAME`
 
@@ -106,4 +106,4 @@ DESCRIPTION
   Add a hook to an existing CLI or plugin.
 ```
 
-_See code: [src/commands/generate/hook.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/generate/hook.ts)_
+_See code: [src/commands/generate/hook.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/generate/hook.ts)_

--- a/docs/init.md
+++ b/docs/init.md
@@ -43,4 +43,4 @@ EXAMPLES
     $ oclif init --topic-separator colons --bin mycli
 ```
 
-_See code: [src/commands/init.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/init.ts)_

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -22,4 +22,4 @@ DESCRIPTION
   Generates plugin manifest json (oclif.manifest.json).
 ```
 
-_See code: [src/commands/manifest.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/manifest.ts)_
+_See code: [src/commands/manifest.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/manifest.ts)_

--- a/docs/pack.md
+++ b/docs/pack.md
@@ -33,7 +33,7 @@ FLAG DESCRIPTIONS
     For more details see the `-Zcompress-type` section at https://man7.org/linux/man-pages/man1/dpkg-deb.1.html
 ```
 
-_See code: [src/commands/pack/deb.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/pack/deb.ts)_
+_See code: [src/commands/pack/deb.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/pack/deb.ts)_
 
 ## `oclif pack macos`
 
@@ -55,7 +55,7 @@ DESCRIPTION
   Add a pretarball script to your package.json if you need to run any scripts before the tarball is created.
 ```
 
-_See code: [src/commands/pack/macos.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/pack/macos.ts)_
+_See code: [src/commands/pack/macos.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/pack/macos.ts)_
 
 ## `oclif pack tarballs`
 
@@ -81,7 +81,7 @@ DESCRIPTION
   Add a pretarball script to your package.json if you need to run any scripts before the tarball is created.
 ```
 
-_See code: [src/commands/pack/tarballs.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/pack/tarballs.ts)_
+_See code: [src/commands/pack/tarballs.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/pack/tarballs.ts)_
 
 ## `oclif pack win`
 
@@ -121,4 +121,4 @@ FLAG DESCRIPTIONS
     There is no way to set a hidden checkbox with "true" as a default...the user can always allow full security
 ```
 
-_See code: [src/commands/pack/win.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/pack/win.ts)_
+_See code: [src/commands/pack/win.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/pack/win.ts)_

--- a/docs/promote.md
+++ b/docs/promote.md
@@ -32,4 +32,4 @@ DESCRIPTION
   Promote CLI builds to a S3 release channel.
 ```
 
-_See code: [src/commands/promote.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/promote.ts)_
+_See code: [src/commands/promote.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/promote.ts)_

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -40,4 +40,4 @@ DESCRIPTION
   Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
 ```
 
-_See code: [src/commands/readme.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/readme.ts)_
+_See code: [src/commands/readme.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/readme.ts)_

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -23,7 +23,7 @@ DESCRIPTION
   Upload deb package built with `pack deb`.
 ```
 
-_See code: [src/commands/upload/deb.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/upload/deb.ts)_
+_See code: [src/commands/upload/deb.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/upload/deb.ts)_
 
 ## `oclif upload macos`
 
@@ -42,7 +42,7 @@ DESCRIPTION
   Upload macos installers built with `pack macos`.
 ```
 
-_See code: [src/commands/upload/macos.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/upload/macos.ts)_
+_See code: [src/commands/upload/macos.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/upload/macos.ts)_
 
 ## `oclif upload tarballs`
 
@@ -62,7 +62,7 @@ DESCRIPTION
   Upload an oclif CLI to S3.
 ```
 
-_See code: [src/commands/upload/tarballs.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/upload/tarballs.ts)_
+_See code: [src/commands/upload/tarballs.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/upload/tarballs.ts)_
 
 ## `oclif upload win`
 
@@ -81,4 +81,4 @@ DESCRIPTION
   Upload windows installers built with `pack win`.
 ```
 
-_See code: [src/commands/upload/win.ts](https://github.com/oclif/oclif/blob/4.17.16/src/commands/upload/win.ts)_
+_See code: [src/commands/upload/win.ts](https://github.com/oclif/oclif/blob/4.17.17-dev.0/src/commands/upload/win.ts)_

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oclif",
   "description": "oclif: create your own CLI",
-  "version": "4.17.16",
+  "version": "4.17.17-dev.0",
   "author": "Salesforce",
   "bin": {
     "oclif": "bin/run.js"

--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -14,7 +14,7 @@ const exec = promisify(execSync)
 const scripts = {
   /* eslint-disable no-useless-escape */
 
-  cmd: (config: Interfaces.Config, additionalCLI?: string | undefined) => `@echo off
+  cmd: (config: Interfaces.Config, additionalCLI?: string, nodeOptions?: string[]) => `@echo off
 setlocal enableextensions
 
 set ${additionalCLI ? `${additionalCLI.toUpperCase()}_BINPATH` : config.scopedEnvVarKey('BINPATH')}=%~dp0\\${
@@ -23,7 +23,7 @@ set ${additionalCLI ? `${additionalCLI.toUpperCase()}_BINPATH` : config.scopedEn
 if exist "%LOCALAPPDATA%\\${config.dirname}\\client\\bin\\${additionalCLI ?? config.bin}.cmd" (
   "%LOCALAPPDATA%\\${config.dirname}\\client\\bin\\${additionalCLI ?? config.bin}.cmd" %*
 ) else (
-  "%~dp0\\..\\client\\bin\\node.exe" "%~dp0\\..\\client\\${
+  "%~dp0\\..\\client\\bin\\node.exe" ${`${nodeOptions?.join(' ')} `}"%~dp0\\..\\client\\${
     additionalCLI ? `${additionalCLI}\\bin\\run` : 'bin\\run'
   }" %*
 )
@@ -288,7 +288,10 @@ the CLI should already exist in a directory named after the CLI that is the root
         await rm(installerBase, {force: true, recursive: true})
         await mkdir(path.join(installerBase, 'bin'), {recursive: true})
         await Promise.all([
-          writeFile(path.join(installerBase, 'bin', `${config.bin}.cmd`), scripts.cmd(config)),
+          writeFile(
+            path.join(installerBase, 'bin', `${config.bin}.cmd`),
+            scripts.cmd(config, undefined, buildConfig.nodeOptions),
+          ),
           writeFile(path.join(installerBase, 'bin', `${config.bin}`), scripts.sh(config)),
           writeFile(
             path.join(installerBase, `${config.bin}.nsi`),


### PR DESCRIPTION
Fixes: https://github.com/forcedotcom/cli/issues/3161

The windows tarball bin gets CLI's node options in the cmd file:
https://github.com/oclif/oclif/blob/356ac3253433bf52184e2ae75574ac09a02e4236/src/tarballs/bin.ts#L43

the installer one doesn't:
https://github.com/oclif/oclif/blob/356ac3253433bf52184e2ae75574ac09a02e4236/src/commands/pack/win.ts#L26

@W-17637923@