### PR TITLE
docs: fix broken contributing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ hello world! (./src/commands/hello/world.ts)
 
 # 🚀 Contributing
 
-See the [contributing guide](./CONRTIBUTING.md).
+See the [contributing guide](./CONTRIBUTING.md).
 
 # 🏭 Related Repositories
 


### PR DESCRIPTION
This PR fixes a broken link I came across while reading your docs.