### PR TITLE
fix: initialize oclif object when building tarballs

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -153,6 +153,7 @@ const updatePJSON = async (c: BuildConfig) => {
   const pjsonPath = path.join(c.workspace(), 'package.json')
   const pjson = await readJSON(pjsonPath)
   pjson.version = c.config.version
+  pjson.oclif = pjson.oclif ?? {}
   pjson.oclif.update = pjson.oclif.update ?? {}
   pjson.oclif.update.s3 = pjson.oclif.update.s3 ?? {}
   pjson.oclif.update.s3.bucket = c.s3Config.bucket


### PR DESCRIPTION
## Summary
Fixes build crash when oclif config is in `.oclifrc.mjs` instead of `package.json`.

## Changes
Initialize `pjson.oclif` object before accessing `pjson.oclif.update` in `updatePJSON` function.

## Testing
Verified `oclif pack tarballs` works with config in `.oclifrc.mjs`.

Fixes #1904

DERIVED FROM #1929 . Thanks to @thedhanawada for creating that one.