### PR TITLE
feat(readme): allow disabling source links

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -48,6 +48,11 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
     'repository-prefix': Flags.string({
       description: 'A template string used to build links to the source code.',
     }),
+    'source-links': Flags.boolean({
+      allowNo: true,
+      default: true,
+      description: 'Include links to the source code for each command.',
+    }),
     'tsconfig-path': Flags.string({
       default: 'tsconfig.json',
       description: 'Path to the tsconfig file',
@@ -100,6 +105,7 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
       pluginDir: this.flags['plugin-directory'],
       readmePath,
       repositoryPrefix: this.flags['repository-prefix'],
+      sourceLinks: this.flags['source-links'],
       version: this.flags.version,
     })
 

--- a/src/readme-generator.ts
+++ b/src/readme-generator.ts
@@ -26,6 +26,7 @@ type Options = {
   pluginDir?: string
   readmePath: string
   repositoryPrefix?: string
+  sourceLinks?: boolean
   version?: string
 }
 
@@ -42,6 +43,7 @@ export default class ReadmeGenerator {
   ) {}
 
   protected commandCode(c: Command.Cached): string | undefined {
+    if (this.options.sourceLinks === false) return
     const pluginName = c.pluginName
     if (!pluginName) return
     const plugin = this.config.plugins.get(pluginName)

--- a/test/unit/readme.test.ts
+++ b/test/unit/readme.test.ts
@@ -47,6 +47,18 @@ describe('readme', () => {
     })
   })
 
+  describe('with --no-source-links flag', () => {
+    it('excludes source code links', async () => {
+      const {result} = await runCommand<string>('readme --dry-run --no-source-links')
+      expect(result).to.not.contain('See code:')
+    })
+
+    it('includes source code links by default', async () => {
+      const {result} = await runCommand<string>('readme --dry-run')
+      expect(result).to.contain('See code:')
+    })
+  })
+
   describe('with custom help that implements formatCommand', () => {
     it('writes custom help to the readme', async () => {
       const rootPath = join(__dirname, '../fixtures/cli-with-custom-help')


### PR DESCRIPTION
For some CLI's, showing links to source locations isn't actually helpful/wanted. This PR adds a new `--[no-]source-links` flag, that lets you disable them should you not want to.

Wasn't sure if I should add a setting to `package.json` or not, but went for the minimal feature set first. 