### PR TITLE
fix: resolve macOS uninstall dirs at runtime

### DIFF
--- a/src/commands/pack/macos.ts
+++ b/src/commands/pack/macos.ts
@@ -50,6 +50,11 @@ ${config.binAliases ? config.binAliases.map((alias) => `sudo rm -rf /usr/local/b
 `,
   uninstall(config: Interfaces.Config, additionalCLI: string | undefined) {
     const packageIdentifier = (config.pjson.oclif as Interfaces.PJSON['plugin']).macos!.identifier!
+    const runtimeDir = (key: 'CACHE_DIR' | 'CONFIG_DIR' | 'DATA_DIR', defaultPath: string) =>
+      config.scopedEnvVarKeys(key).reduceRight((fallback, envKey) => `\${${envKey}:-${fallback}}`, defaultPath)
+    const dataDir = runtimeDir('DATA_DIR', `$REAL_HOME/.local/share/${config.dirname}`)
+    const cacheDir = runtimeDir('CACHE_DIR', `$REAL_HOME/Library/Caches/${config.dirname}`)
+    const configDir = runtimeDir('CONFIG_DIR', `$REAL_HOME/.config/${config.dirname}`)
     return `#!/usr/bin/env bash
 
 #Parameters
@@ -112,17 +117,23 @@ else
   echo "[2/3] [ERROR] Could not delete application information" >&2
 fi
 
+REAL_USER="\${SUDO_USER:-$(logname 2>/dev/null || id -un)}"
+REAL_HOME=$(eval echo "~$REAL_USER")
+DATA_DIR="${dataDir}"
+CACHE_DIR="${cacheDir}"
+CONFIG_DIR="${configDir}"
+
 #remove application source distribution
 [ -e "/usr/local/lib/${config.dirname}" ] && rm -rf "/usr/local/lib/${config.dirname}"
 
 #remove application data directory
-[ -e "${config.dataDir}" ] && rm -rf "${config.dataDir}"
+[ -e "$DATA_DIR" ] && rm -rf "$DATA_DIR"
 
 #remove application cache directory
-[ -e "${config.cacheDir}" ] && rm -rf "${config.cacheDir}"
+[ -e "$CACHE_DIR" ] && rm -rf "$CACHE_DIR"
 
 #remove application config directory
-[ -e "${config.configDir}" ] && rm -rf "${config.configDir}"
+[ -e "$CONFIG_DIR" ] && rm -rf "$CONFIG_DIR"
 
 if [ $? -eq 0 ]
 then

--- a/test/integration/macos.test.ts
+++ b/test/integration/macos.test.ts
@@ -1,6 +1,6 @@
 import {runCommand} from '@oclif/test'
 import {expect} from 'chai'
-import {emptyDir, writeJSON} from 'fs-extra'
+import {emptyDir, readFile, writeJSON} from 'fs-extra'
 import _ from 'lodash'
 import {createWriteStream} from 'node:fs'
 import path from 'node:path'
@@ -16,49 +16,80 @@ const originalPJSON = _.cloneDeep(pjson)
 const onlyMacos = process.platform === 'darwin' ? it : it.skip
 const testRun = `test-${Math.random().toString().split('.')[1].slice(0, 4)}`
 
-describe('publish:macos', () => {
+describe('macos', () => {
   const cwd = process.cwd()
-  let pkg: string
-  let sha: string
-  let bucket: string
-  let basePrefix: string
-  const root = path.join(__dirname, '../tmp/test/publish')
 
-  beforeEach(async () => {
-    pjson.version = `${pjson.version}-${testRun}`
-    pjson.oclif.update.node.version = process.versions.node
-    pjson.oclif.binAliases = ['oclif2']
-    bucket = pjson.oclif.update.s3.bucket
-    basePrefix = pjson.oclif.update.s3.folder
-    await deleteFolder(bucket, `${basePrefix}/versions/${pjson.version}/`)
-    await writeJSON(pjsonPath, pjson, {spaces: 2})
-    await emptyDir(root)
+  describe('pack', () => {
+    onlyMacos('resolves the installing user home in uninstall script', async () => {
+      await runCommand('pack macos')
+
+      const uninstallScript = await readFile(path.join(cwd, 'tmp', 'darwin-arm64', 'oclif', 'bin', 'uninstall'), 'utf8')
+      const dollar = '$'
+      const shellParamExpansion = (expression: string) => `${dollar}{${expression}}`
+
+      expect(uninstallScript).to.contain(
+        `REAL_USER="${shellParamExpansion('SUDO_USER:-$(logname 2>/dev/null || id -un)')}"`,
+      )
+      expect(uninstallScript).to.contain('REAL_HOME=$(eval echo "~$REAL_USER")')
+      expect(uninstallScript).to.contain(
+        `DATA_DIR="${shellParamExpansion('OCLIF_DATA_DIR:-$REAL_HOME/.local/share/oclif')}"`,
+      )
+      expect(uninstallScript).to.contain(
+        `CACHE_DIR="${shellParamExpansion('OCLIF_CACHE_DIR:-$REAL_HOME/Library/Caches/oclif')}"`,
+      )
+      expect(uninstallScript).to.contain(
+        `CONFIG_DIR="${shellParamExpansion('OCLIF_CONFIG_DIR:-$REAL_HOME/.config/oclif')}"`,
+      )
+      expect(uninstallScript).to.contain('[ -e "$DATA_DIR" ] && rm -rf "$DATA_DIR"')
+      expect(uninstallScript).to.contain('[ -e "$CACHE_DIR" ] && rm -rf "$CACHE_DIR"')
+      expect(uninstallScript).to.contain('[ -e "$CONFIG_DIR" ] && rm -rf "$CONFIG_DIR"')
+      expect(uninstallScript).to.not.contain(process.env.HOME!)
+    })
   })
 
-  afterEach(async () => {
-    if (!process.env.PRESERVE_ARTIFACTS) {
+  describe('publish', () => {
+    let pkg: string
+    let sha: string
+    let bucket: string
+    let basePrefix: string
+    const root = path.join(__dirname, '../tmp/test/publish')
+
+    beforeEach(async () => {
+      pjson.version = `${pjson.version}-${testRun}`
+      pjson.oclif.update.node.version = process.versions.node
+      pjson.oclif.binAliases = ['oclif2']
+      bucket = pjson.oclif.update.s3.bucket
+      basePrefix = pjson.oclif.update.s3.folder
       await deleteFolder(bucket, `${basePrefix}/versions/${pjson.version}/`)
-    }
+      await writeJSON(pjsonPath, pjson, {spaces: 2})
+      await emptyDir(root)
+    })
 
-    await writeJSON(pjsonPath, originalPJSON, {spaces: 2})
-  })
+    afterEach(async () => {
+      if (!process.env.PRESERVE_ARTIFACTS) {
+        await deleteFolder(bucket, `${basePrefix}/versions/${pjson.version}/`)
+      }
 
-  onlyMacos('publishes valid releases', async () => {
-    await runCommand('pack macos')
+      await writeJSON(pjsonPath, originalPJSON, {spaces: 2})
+    })
 
-    // install the intel silicon pkg
-    ;[pkg, sha] = await findDistFileSha(cwd, 'macos', (f) => f.endsWith('x64.pkg'))
-    exec(`sudo installer -pkg ${path.join(cwd, 'dist', 'macos', pkg)} -target /`)
-    expect(exec('oclif --version').stdout).to.contain(`oclif/${pjson.version}`)
-    // tests binAlias
-    expect(exec('oclif2 --version').stdout).to.contain(`oclif/${pjson.version}`)
+    onlyMacos('publishes valid releases', async () => {
+      await runCommand('pack macos')
 
-    await runCommand('upload macos')
+      // install the intel silicon pkg
+      ;[pkg, sha] = await findDistFileSha(cwd, 'macos', (f) => f.endsWith('x64.pkg'))
+      exec(`sudo installer -pkg ${path.join(cwd, 'dist', 'macos', pkg)} -target /`)
+      expect(exec('oclif --version').stdout).to.contain(`oclif/${pjson.version}`)
+      // tests binAlias
+      expect(exec('oclif2 --version').stdout).to.contain(`oclif/${pjson.version}`)
 
-    const {default: got} = await import('got')
-    await pipeline(
-      got.stream(`https://${developerSalesforceCom}/${basePrefix}/versions/${pjson.version}/${sha}/${pkg}`),
-      createWriteStream(pkg),
-    )
+      await runCommand('upload macos')
+
+      const {default: got} = await import('got')
+      await pipeline(
+        got.stream(`https://${developerSalesforceCom}/${basePrefix}/versions/${pjson.version}/${sha}/${pkg}`),
+        createWriteStream(pkg),
+      )
+    })
   })
 })


### PR DESCRIPTION
Fixes #1996

`pack macos` currently interpolates `config.dataDir`, `config.cacheDir`, and `config.configDir` into `bin/uninstall` when the package is built, so the generated script points at the builder's home directory.

This changes the uninstall template to resolve the uninstalling user's home at runtime and derive the data/cache/config directories from that user, while still honoring scoped `*_DIR` overrides.

Validation:
- `yarn test:integration:macos --grep "resolves the installing user home in uninstall script"`
- `node ./bin/run.js pack macos`
  - verified the generated `bin/uninstall` script no longer contains build-machine `/Users/...` paths
