### PR TITLE
fix: support CRLF readme tags

### DIFF
--- a/src/readme-generator.ts
+++ b/src/readme-generator.ts
@@ -209,7 +209,7 @@ export default class ReadmeGenerator {
   protected replaceTag(readme: string, tag: string, body: string): string {
     if (readme.includes(`<!-- ${tag} -->`)) {
       if (readme.includes(`<!-- ${tag}stop -->`)) {
-        readme = readme.replace(new RegExp(`<!-- ${tag} -->(.|\n)*<!-- ${tag}stop -->`, 'm'), `<!-- ${tag} -->`)
+        readme = readme.replace(new RegExp(`<!-- ${tag} -->[\\s\\S]*?<!-- ${tag}stop -->`, 'm'), `<!-- ${tag} -->`)
       }
 
       ux.stdout(`replacing <!-- ${tag} --> in ${this.options.readmePath}`)

--- a/test/unit/readme-generator.test.ts
+++ b/test/unit/readme-generator.test.ts
@@ -263,6 +263,19 @@ Title of Doc
     })
   })
 
+  describe('replaceTag', () => {
+    it('should replace tags when the README uses CRLF line endings', () => {
+      const generator = new TestReadmeGenerator(config, {outputDir: 'docs', readmePath: 'README.md'})
+      // @ts-expect-error because protected method
+      const rendered = generator.replaceTag(
+        '# Usage\r\n\r\n<!-- usage -->\r\nold usage\r\n<!-- usagestop -->\r\n\r\n# Commands\r\n',
+        'usage',
+        'new usage',
+      )
+      expect(rendered).to.equal('# Usage\r\n\r\n<!-- usage -->\nnew usage\n<!-- usagestop -->\r\n\r\n# Commands\r\n')
+    })
+  })
+
   describe('usage', () => {
     it('should render usage based on Config', async () => {
       const generator = new TestReadmeGenerator(config, {outputDir: 'docs', readmePath: 'README.md'})


### PR DESCRIPTION
## Summary
- Update README tag replacement to match sections with CRLF line endings.
- Add a unit test covering CRLF-delimited README usage tags.

Fixes #793

## Testing
- `yarn mocha --forbid-only test/unit/readme-generator.test.ts`
- `yarn build`
- `yarn test` (passes; lint reports existing TODO warnings only)
