### PR TITLE
Update command to use exec for node process

### DIFF
--- a/src/commands/pack/deb.ts
+++ b/src/commands/pack/deb.ts
@@ -33,7 +33,7 @@ DIR=\$(get_script_dir)
 export ${config.scopedEnvVarKey('UPDATE_INSTRUCTIONS')}="update with \\"sudo apt update && sudo apt install ${
     config.bin
   }\\""
-\$DIR/node \$DIR/run "\$@"
+exec \$DIR/node \$DIR/run "\$@"
 `,
   /* eslint-enable no-useless-escape */
   control: (config: Tarballs.BuildConfig, arch: string) => `Package: ${config.config.bin}


### PR DESCRIPTION
Currently, the node process is launched directly. However, if the process is started by a process manager such as systemd, killing the main process (which is, in fact, a bash process and not the node process) will do nothing: bash will orphan the node process and leave it running.

By using exec, we're substituting the bash process with the node one: there is no bash process to kill anymore, only the node process directly.