### PR TITLE
sec(installer): default Windows Defender exclusion to opt-in for improved security

### DIFF
--- a/src/commands/pack/win.ts
+++ b/src/commands/pack/win.ts
@@ -102,9 +102,9 @@ Section "Set PATH to ${config.name}"
   Call AddToPath
 SectionEnd
 
-Section ${defenderOptional ? '/o ' : ''}"${hideDefenderOption ? '-' : ''}Add %LOCALAPPDATA%\\${
+Section ${defenderOptional ? '/o ' : ''}"${hideDefenderOption ? '-' : ''}Exclude %LOCALAPPDATA%\\${
     config.dirname
-  } to Windows Defender exclusions (highly recommended for performance!)"
+  } from Windows Defender scanning (may improve performance, but reduces antivirus protection for this folder)"
   ExecWait '"$0" /C powershell -ExecutionPolicy Bypass -Command "$\\"& {Add-MpPreference -ExclusionPath $\\"$LOCALAPPDATA\\${config.dirname}$\\"}$\\"" -FFFeatureOff SW_HIDE'
 SectionEnd
 
@@ -245,9 +245,9 @@ the CLI should already exist in a directory named after the CLI that is the root
     'defender-exclusion': Flags.option({
       options: ['checked', 'unchecked', 'hidden'] as const,
     })({
-      default: 'checked',
+      default: 'unchecked',
       description:
-        'There is no way to set a hidden checkbox with "true" as a default...the user can always allow full security',
+        'Defaults to "unchecked" so end users opt in rather than opt out of excluding the install directory from Windows Defender scanning. Note: "hidden" always disables the exclusion, since there is no way to set a hidden checkbox with "true" as a default...the user can always allow full security',
 
       summary: `Set to "checked" or "unchecked" to set the default value for the checkbox.  Set to "hidden" to hide the option (will let defender do its thing).`,
     }),


### PR DESCRIPTION
## Summary
This PR changes the default behavior of the Windows Defender exclusion prompt during installation from **opt-out** (checked by default) to **opt-in** (unchecked by default). It also reframes the UI copy to ensure users are fully informed about the security trade-offs of this exclusion.

## Why?
Previously, the installer defaulted to adding the installation directory to Windows Defender exclusions. While this can improve execution performance, disabling antivirus scanning for a user directory by default is a security anti-pattern (opt-out). 

To prioritize user security and align with best practices, we are switching this to an **explicit opt-in** and updating the copy to make the security implications clear.

## Changes
* **UI Copy Refactoring (`src/commands/pack/win.ts`):** * Updated the installer section title from *"Add... to Windows Defender exclusions (highly recommended for performance!)"* to *"Exclude... from Windows Defender scanning (may improve performance, but reduces antivirus protection for this folder)"*. This provides a more balanced and transparent warning.
* **Default Flag Value:** * Changed the default value of the `defender-exclusion` option flag from `checked` to `unchecked`.
  * Updated the flag's description to clearly document this change and explain the reasoning behind the new default behavior.